### PR TITLE
Lint with same go version as build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           version: ${{ env.GOLANGCI_VERSION }}
+          skip-go-installation: true
 
   check-diff:
     runs-on: ubuntu-18.04

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -47,7 +47,7 @@ func New(err error, msg string, errType ErrorType) *Error {
 // IsNotFound returns true if the error is an Upbound SDK NotFound error, and
 // false otherwise.
 func IsNotFound(err error) bool {
-	e, ok := err.(interface {
+	e, ok := err.(interface { // nolint:errorlint
 		IsNotFound() bool
 	})
 	if !ok {


### PR DESCRIPTION
Updates lint workflow to setup go version beforehand so that it uses the
same as all build and publish workflows

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

This fixes the currently failing lint workflow on `main`.