### PR TITLE
Update controlplane to use account instead of namespace

### DIFF
--- a/_examples/controlplanes/main.go
+++ b/_examples/controlplanes/main.go
@@ -72,7 +72,7 @@ func main() {
 	fmt.Println("Creating control plane...")
 	cp, err := client.Create(context.Background(), &controlplanes.ControlPlaneCreateParameters{
 		Name:        "test",
-		Namespace:   user,
+		Account:     user,
 		Description: "An example control plane.",
 	})
 	if err != nil {

--- a/service/controlplanes/types.go
+++ b/service/controlplanes/types.go
@@ -56,7 +56,7 @@ type ControlPlaneResponse struct {
 
 // ControlPlaneCreateParameters are the parameters for creating a control plane.
 type ControlPlaneCreateParameters struct {
-	Namespace     string `json:"namespace"`
+	Account       string `json:"account"`
 	Name          string `json:"name"`
 	Description   string `json:"description"`
 	SelfHosted    bool   `json:"selfHosted,omitempty"`


### PR DESCRIPTION
Control planes are now under an account rather than a namespace.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Follow-up to #14 