### PR TITLE
Add support for managing robots

### DIFF
--- a/service/common/data.go
+++ b/service/common/data.go
@@ -1,0 +1,35 @@
+// Copyright 2022 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import "github.com/google/uuid"
+
+// RelationshipSet represents set of relationships.
+type RelationshipSet map[string]interface{}
+
+// AttributeSet represents set of attributes.
+type AttributeSet map[string]interface{}
+
+// Meta represents metadata.
+type Meta map[string]interface{}
+
+// DataSet represents a set of data for an entity.
+type DataSet struct {
+	Type            string    `json:"type"`
+	ID              uuid.UUID `json:"id"`
+	AttributeSet    `json:"attributes"`
+	RelationshipSet `json:"relationships"`
+	Meta            `json:"meta"`
+}

--- a/service/organizations/client.go
+++ b/service/organizations/client.go
@@ -17,6 +17,7 @@ package organizations
 import (
 	"context"
 	"net/http"
+	"path"
 	"strconv"
 
 	"github.com/upbound/up-sdk-go"
@@ -73,6 +74,22 @@ func (c *Client) List(ctx context.Context) ([]Organization, error) {
 		return nil, err
 	}
 	return orgs, nil
+}
+
+// ListRobots list all robots the user can access in the organization on
+// Upbound.
+// TODO(hasheddan): move this to robots client when API is updated.
+func (c *Client) ListRobots(ctx context.Context, id uint) ([]Robot, error) {
+	req, err := c.Client.NewRequest(ctx, http.MethodGet, basePath, path.Join(strconv.FormatUint(uint64(id), 10), "robots"), nil)
+	if err != nil {
+		return nil, err
+	}
+	rs := []Robot{}
+	err = c.Client.Do(req, &rs)
+	if err != nil {
+		return nil, err
+	}
+	return rs, nil
 }
 
 // Delete an organization on Upbound.

--- a/service/organizations/client_test.go
+++ b/service/organizations/client_test.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"net/http"
 	"net/url"
+	"path"
+	"strconv"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -213,6 +215,107 @@ func TestList(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want, res); diff != "" {
 				t.Errorf("\n%s\nList(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestListRobots(t *testing.T) {
+	errBoom := errors.New("boom")
+	testURL, _ := url.Parse("https://localhost:8080")
+	var id uint = 999
+	type args struct {
+		org uint
+	}
+	cases := map[string]struct {
+		reason string
+		args   args
+		cfg    *up.Config
+		want   []Robot
+		err    error
+	}{
+		"NewRequestFailed": {
+			reason: "Failing to construct a request should return an error.",
+			args: args{
+				org: id,
+			},
+			cfg: &up.Config{
+				Client: &fake.MockClient{
+					MockNewRequest: fake.NewMockNewRequestFn(nil, errBoom),
+				},
+			},
+			err: errBoom,
+		},
+		"DoFailed": {
+			reason: "Failing to execute request should return an error.",
+			args: args{
+				org: id,
+			},
+			cfg: &up.Config{
+				Client: &fake.MockClient{
+					MockNewRequest: func(ctx context.Context, method, prefix, urlPath string, body interface{}) (*http.Request, error) {
+						if method != http.MethodGet {
+							t.Errorf("unexpected method: %s", method)
+						}
+						if prefix != basePath {
+							t.Errorf("unexpected prefix: %s", method)
+						}
+						if urlPath != path.Join(strconv.FormatUint(uint64(id), 10), "robots") {
+							t.Errorf("unexpected path: %s", urlPath)
+						}
+						r, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, testURL.String(), nil)
+						return r, nil
+					},
+					MockDo: func(req *http.Request, _ interface{}) error {
+						if req.URL.Host != testURL.Host {
+							t.Errorf("unexpected host: %s", req.URL.Host)
+						}
+						return errBoom
+					},
+				},
+			},
+			err: errBoom,
+		},
+		"Successful": {
+			reason: "A successful request should not return an error.",
+			args: args{
+				org: id,
+			},
+			cfg: &up.Config{
+				Client: &fake.MockClient{
+					MockNewRequest: func(ctx context.Context, method, prefix, urlPath string, body interface{}) (*http.Request, error) {
+						if method != http.MethodGet {
+							t.Errorf("unexpected method: %s", method)
+						}
+						if prefix != basePath {
+							t.Errorf("unexpected prefix: %s", method)
+						}
+						if urlPath != path.Join(strconv.FormatUint(uint64(id), 10), "robots") {
+							t.Errorf("unexpected path: %s", urlPath)
+						}
+						r, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, testURL.String(), nil)
+						return r, nil
+					},
+					MockDo: func(req *http.Request, _ interface{}) error {
+						if req.URL.Host != testURL.Host {
+							t.Errorf("unexpected host: %s", req.URL.Host)
+						}
+						return nil
+					},
+				},
+			},
+			want: []Robot{},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			c := NewClient(tc.cfg)
+			res, err := c.ListRobots(context.Background(), tc.args.org)
+			if diff := cmp.Diff(tc.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nListRobots(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want, res); diff != "" {
+				t.Errorf("\n%s\nListRobots(...): -want, +got:\n%s", tc.reason, diff)
 			}
 		})
 	}

--- a/service/organizations/types.go
+++ b/service/organizations/types.go
@@ -14,6 +14,12 @@
 
 package organizations
 
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
 // Organization is an organization on Upbound.
 type Organization struct {
 	ID                   uint                        `json:"id"`
@@ -22,6 +28,16 @@ type Organization struct {
 	CreatorID            uint                        `json:"creatorId"`
 	Role                 OrganizationPermissionGroup `json:"role"`
 	ReservedEnvironments int                         `json:"reservedEnvironments"`
+}
+
+// Robot is a robot account on Upbound.
+type Robot struct {
+	ID          uuid.UUID   `json:"id"`
+	Name        string      `json:"name"`
+	Description string      `json:"description"`
+	TeamIDs     []uuid.UUID `json:"teamIDs"`
+	TokenIDs    []uuid.UUID `json:"tokenIDs"`
+	CreatedAt   time.Time   `json:"createdAt"`
 }
 
 // OrganizationPermissionGroup is the type of permission a user has in the

--- a/service/robots/client.go
+++ b/service/robots/client.go
@@ -1,0 +1,82 @@
+// Copyright 2021 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package robots
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/google/uuid"
+
+	"github.com/upbound/up-sdk-go"
+)
+
+const (
+	basePath = "v2/robots"
+)
+
+// Client is an robots client.
+type Client struct {
+	*up.Config
+}
+
+// NewClient builds an robots client from the passed config.
+func NewClient(cfg *up.Config) *Client {
+	return &Client{
+		cfg,
+	}
+}
+
+// Create a robot on Upbound.
+func (c *Client) Create(ctx context.Context, params *RobotCreateParameters) (*RobotResponse, error) {
+	body := &robotCreateRequest{
+		Data: robotCreateParameters{
+			Type:                  robotBody,
+			RobotCreateParameters: params,
+		},
+	}
+	req, err := c.Client.NewRequest(ctx, http.MethodPost, basePath, "", body)
+	if err != nil {
+		return nil, err
+	}
+	t := &RobotResponse{}
+	err = c.Client.Do(req, &t)
+	if err != nil {
+		return nil, err
+	}
+	return t, nil
+}
+
+// Get gets a robot on Upbound.
+func (c *Client) Get(ctx context.Context, id uuid.UUID) (*RobotResponse, error) {
+	req, err := c.Client.NewRequest(ctx, http.MethodDelete, basePath, id.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	r := &RobotResponse{}
+	if err := c.Client.Do(req, r); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+// Delete an robot on Upbound.
+func (c *Client) Delete(ctx context.Context, id uuid.UUID) error {
+	req, err := c.Client.NewRequest(ctx, http.MethodDelete, basePath, id.String(), nil)
+	if err != nil {
+		return err
+	}
+	return c.Client.Do(req, nil)
+}

--- a/service/robots/client.go
+++ b/service/robots/client.go
@@ -60,7 +60,7 @@ func (c *Client) Create(ctx context.Context, params *RobotCreateParameters) (*Ro
 }
 
 // Get gets a robot on Upbound.
-func (c *Client) Get(ctx context.Context, id uuid.UUID) (*RobotResponse, error) {
+func (c *Client) Get(ctx context.Context, id uuid.UUID) (*RobotResponse, error) { // nolint:interfacer
 	req, err := c.Client.NewRequest(ctx, http.MethodDelete, basePath, id.String(), nil)
 	if err != nil {
 		return nil, err
@@ -73,7 +73,7 @@ func (c *Client) Get(ctx context.Context, id uuid.UUID) (*RobotResponse, error) 
 }
 
 // Delete an robot on Upbound.
-func (c *Client) Delete(ctx context.Context, id uuid.UUID) error {
+func (c *Client) Delete(ctx context.Context, id uuid.UUID) error { // nolint:interfacer
 	req, err := c.Client.NewRequest(ctx, http.MethodDelete, basePath, id.String(), nil)
 	if err != nil {
 		return err

--- a/service/robots/client_test.go
+++ b/service/robots/client_test.go
@@ -1,0 +1,188 @@
+// Copyright 2021 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package robots
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+
+	"github.com/upbound/up-sdk-go"
+	"github.com/upbound/up-sdk-go/fake"
+)
+
+func TestCreate(t *testing.T) {
+	errBoom := errors.New("boom")
+
+	cases := map[string]struct {
+		reason string
+		cfg    *up.Config
+		params *RobotCreateParameters
+		want   *RobotResponse
+		err    error
+	}{
+		"NewRequestFailed": {
+			reason: "Failing to construct a request should return an error.",
+			cfg: &up.Config{
+				Client: &fake.MockClient{
+					MockNewRequest: fake.NewMockNewRequestFn(nil, errBoom),
+				},
+			},
+			err: errBoom,
+		},
+		"DoFailed": {
+			reason: "Failing to execute request should return an error.",
+			cfg: &up.Config{
+				Client: &fake.MockClient{
+					MockNewRequest: fake.NewMockNewRequestFn(nil, nil),
+					MockDo:         fake.NewMockDoFn(errBoom),
+				},
+			},
+			err: errBoom,
+		},
+		"Successful": {
+			reason: "A successful request should not return an error.",
+			cfg: &up.Config{
+				Client: &fake.MockClient{
+					MockNewRequest: fake.NewMockNewRequestFn(nil, nil),
+					MockDo:         fake.NewMockDoFn(nil),
+				},
+			},
+			want: &RobotResponse{},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			c := NewClient(tc.cfg)
+			res, err := c.Create(context.Background(), tc.params)
+			if diff := cmp.Diff(tc.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nCreate(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want, res); diff != "" {
+				t.Errorf("\n%s\nCreate(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestGet(t *testing.T) {
+	errBoom := errors.New("boom")
+	uid := uuid.MustParse("4654b8b5-c01d-4fbe-8800-22c347c21383")
+
+	cases := map[string]struct {
+		reason string
+		cfg    *up.Config
+		id     uuid.UUID
+		want   *RobotResponse
+		err    error
+	}{
+		"NewRequestFailed": {
+			reason: "Failing to construct a request should return an error.",
+			cfg: &up.Config{
+				Client: &fake.MockClient{
+					MockNewRequest: fake.NewMockNewRequestFn(nil, errBoom),
+				},
+			},
+			id:  uid,
+			err: errBoom,
+		},
+		"DoFailed": {
+			reason: "Failing to execute request should return an error.",
+			cfg: &up.Config{
+				Client: &fake.MockClient{
+					MockNewRequest: fake.NewMockNewRequestFn(nil, nil),
+					MockDo:         fake.NewMockDoFn(errBoom),
+				},
+			},
+			id:  uid,
+			err: errBoom,
+		},
+		"Successful": {
+			reason: "A successful request should not return an error.",
+			cfg: &up.Config{
+				Client: &fake.MockClient{
+					MockNewRequest: fake.NewMockNewRequestFn(nil, nil),
+					MockDo:         fake.NewMockDoFn(nil),
+				},
+			},
+			id:   uid,
+			want: &RobotResponse{},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			c := NewClient(tc.cfg)
+			res, err := c.Get(context.Background(), tc.id)
+			if diff := cmp.Diff(tc.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nGet(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want, res); diff != "" {
+				t.Errorf("\n%s\nGet(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestDelete(t *testing.T) {
+	errBoom := errors.New("boom")
+
+	cases := map[string]struct {
+		reason string
+		cfg    *up.Config
+		err    error
+	}{
+		"NewRequestFailed": {
+			reason: "Failing to construct a request should return an error.",
+			cfg: &up.Config{
+				Client: &fake.MockClient{
+					MockNewRequest: fake.NewMockNewRequestFn(nil, errBoom),
+				},
+			},
+			err: errBoom,
+		},
+		"DoFailed": {
+			reason: "Failing to execute request should return an error.",
+			cfg: &up.Config{
+				Client: &fake.MockClient{
+					MockNewRequest: fake.NewMockNewRequestFn(nil, nil),
+					MockDo:         fake.NewMockDoFn(errBoom),
+				},
+			},
+			err: errBoom,
+		},
+		"Successful": {
+			reason: "A successful request should not return an error.",
+			cfg: &up.Config{
+				Client: &fake.MockClient{
+					MockNewRequest: fake.NewMockNewRequestFn(nil, nil),
+					MockDo:         fake.NewMockDoFn(nil),
+				},
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			c := NewClient(tc.cfg)
+			err := c.Delete(context.Background(), uuid.UUID{})
+			if diff := cmp.Diff(tc.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nDelete(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/service/robots/types.go
+++ b/service/robots/types.go
@@ -1,0 +1,89 @@
+// Copyright 2021 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package robots
+
+import (
+	"github.com/upbound/up-sdk-go/service/common"
+)
+
+// RobotOwnerType is the type of owner of the robot.
+type RobotOwnerType string
+
+// Robots can be owned by an organization.
+const (
+	RobotOwnerOrganization RobotOwnerType = "organization"
+)
+
+// bodyType is the type of request in the data body.
+type bodyType string
+
+const (
+	// The only supported body type is robots.
+	robotBody bodyType = "robots"
+)
+
+// RobotsResponse is the response returned from robot operations.
+// TODO(hasheddan): consider making robot responses strongly typed.
+type RobotsResponse struct { //nolint:golint
+	DataSet []common.DataSet `json:"data"`
+}
+
+// RobotCreateParameters are the parameters for creating a robot.
+type RobotCreateParameters struct {
+	Attributes    RobotAttributes    `json:"attributes"`
+	Relationships RobotRelationships `json:"relationships,omitempty"`
+}
+
+// robotCreateParameters is a wrapper around the public RobotCreateParameters
+// struct which adds non-configurable fields.
+type robotCreateParameters struct {
+	// Type must always be "robots".
+	Type                   bodyType `json:"type"`
+	*RobotCreateParameters `json:",inline"`
+}
+
+// robotCreateRequest wraps robotCreateRequest with the proper request structure
+// for the Upbound API.
+type robotCreateRequest struct {
+	Data robotCreateParameters `json:"data"`
+}
+
+// RobotRelationships represents relationships for a robot.
+type RobotRelationships struct {
+	Owner RobotOwner `json:"organization"`
+}
+
+// RobotOwner represents owner of a robot.
+type RobotOwner struct {
+	Data RobotOwnerData `json:"data"`
+}
+
+// RobotOwnerData describes a robot owner.
+type RobotOwnerData struct {
+	Type RobotOwnerType `json:"type"`
+	ID   string         `json:"id"`
+}
+
+// RobotResponse is the response returned from robot operations.
+// TODO(hasheddan): consider making robot responses strongly typed.
+type RobotResponse struct {
+	common.DataSet `json:"data"`
+}
+
+// RobotAttributes are the attributes of a robot.
+type RobotAttributes struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}

--- a/service/tokens/types.go
+++ b/service/tokens/types.go
@@ -16,6 +16,7 @@ package tokens
 
 import (
 	"github.com/google/uuid"
+
 	"github.com/upbound/up-sdk-go/service/common"
 )
 

--- a/service/tokens/types.go
+++ b/service/tokens/types.go
@@ -14,7 +14,10 @@
 
 package tokens
 
-import "github.com/google/uuid"
+import (
+	"github.com/google/uuid"
+	"github.com/upbound/up-sdk-go/service/common"
+)
 
 // TokenOwnerType is the type of owner of the token.
 type TokenOwnerType string
@@ -37,31 +40,13 @@ const (
 // TokenResponse is the response returned from token operations.
 // TODO(hasheddan): consider making token responses strongly typed.
 type TokenResponse struct {
-	DataSet `json:"data"`
+	common.DataSet `json:"data"`
 }
 
 // TokensResponse is the response returned from token operations.
 // TODO(hasheddan): consider making token responses strongly typed.
 type TokensResponse struct { //nolint:golint
-	DataSet []DataSet `json:"data"`
-}
-
-// RelationshipSet represents set of relationships.
-type RelationshipSet map[string]interface{}
-
-// AttributeSet represents set of attributes.
-type AttributeSet map[string]interface{}
-
-// Meta represents metadata.
-type Meta map[string]interface{}
-
-// DataSet represents a set of data in a token response body.
-type DataSet struct {
-	Type            string    `json:"type"`
-	ID              uuid.UUID `json:"id"`
-	AttributeSet    `json:"attributes"`
-	RelationshipSet `json:"relationships"`
-	Meta            `json:"meta"`
+	DataSet []common.DataSet `json:"data"`
 }
 
 // TokenCreateParameters are the parameters for creating a token.


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->


Adds support for managing robots and listing them in the context of an organization.

xref https://github.com/upbound/up/issues/215

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

Covered via unit tests and tested against API with CLI.

```
🤖 (up) go run ./cmd/up robot create dan-cli -a upbound
upbound/dan-cli  created
🤖 (up) go run ./cmd/up robot list -a upbound
NAME                        ID                                     DESCRIPTION                                                      CREATED
...
dan-cli                     f33f5369-39b8-4033-95e6-47b9a3eba470                                                                    31s    
...   
🤖 (up) go run ./cmd/up robot delete dan-cli -a upbound
upbound/dan-cli deleted
```