### PR TITLE
Add client to manage org users

### DIFF
--- a/service/organizations/client.go
+++ b/service/organizations/client.go
@@ -16,6 +16,7 @@ package organizations
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"path"
 	"strconv"
@@ -95,6 +96,62 @@ func (c *Client) ListRobots(ctx context.Context, id uint) ([]Robot, error) {
 // Delete an organization on Upbound.
 func (c *Client) Delete(ctx context.Context, id uint) error {
 	req, err := c.Client.NewRequest(ctx, http.MethodDelete, basePath, strconv.FormatUint(uint64(id), 10), nil)
+	if err != nil {
+		return err
+	}
+	return c.Client.Do(req, nil)
+}
+
+// ListInvites list all invites for the organization on Upbound.
+func (c *Client) ListInvites(ctx context.Context, orgID uint) ([]Invite, error) {
+	req, err := c.Client.NewRequest(ctx, http.MethodGet, basePath, fmt.Sprintf("%d/invites", orgID), nil)
+	if err != nil {
+		return nil, err
+	}
+	invites := []Invite{}
+	err = c.Client.Do(req, &invites)
+	if err != nil {
+		return nil, err
+	}
+	return invites, nil
+}
+
+// DeleteInvite deletes an invite for the organization on Upbound.
+func (c *Client) DeleteInvite(ctx context.Context, orgID uint, inviteID uint) error {
+	req, err := c.Client.NewRequest(ctx, http.MethodDelete, basePath, fmt.Sprintf("%d/invites/%d", orgID, inviteID), nil)
+	if err != nil {
+		return err
+	}
+	return c.Client.Do(req, nil)
+}
+
+// CreateInvite creates an invite for the organization on Upbound.
+func (c *Client) CreateInvite(ctx context.Context, orgID uint, params *OrganizationInviteCreateParameters) error {
+	req, err := c.Client.NewRequest(ctx, http.MethodPost, basePath, fmt.Sprintf("%d/invites", orgID), params)
+	if err != nil {
+		return err
+	}
+
+	return c.Client.Do(req, nil)
+}
+
+// ListMembers list all members for the organization on Upbound.
+func (c *Client) ListMembers(ctx context.Context, orgID uint) ([]Member, error) {
+	req, err := c.Client.NewRequest(ctx, http.MethodGet, basePath, fmt.Sprintf("%d/members", orgID), nil)
+	if err != nil {
+		return nil, err
+	}
+	members := []Member{}
+	err = c.Client.Do(req, &members)
+	if err != nil {
+		return nil, err
+	}
+	return members, nil
+}
+
+// RemoveMember removes a member for the organization on Upbound.
+func (c *Client) RemoveMember(ctx context.Context, orgID uint, userID uint) error {
+	req, err := c.Client.NewRequest(ctx, http.MethodDelete, basePath, fmt.Sprintf("%d/members/%d", orgID, userID), nil)
 	if err != nil {
 		return err
 	}

--- a/service/organizations/client_test.go
+++ b/service/organizations/client_test.go
@@ -368,3 +368,350 @@ func TestDelete(t *testing.T) {
 		})
 	}
 }
+
+func TestRemoveMember(t *testing.T) {
+	errBoom := errors.New("boom")
+
+	cases := map[string]struct {
+		reason string
+		cfg    *up.Config
+		err    error
+	}{
+		"NewRequestFailed": {
+			reason: "Failing to construct a request should return an error.",
+			cfg: &up.Config{
+				Client: &fake.MockClient{
+					MockNewRequest: fake.NewMockNewRequestFn(nil, errBoom),
+				},
+			},
+			err: errBoom,
+		},
+		"DoFailed": {
+			reason: "Failing to execute request should return an error.",
+			cfg: &up.Config{
+				Client: &fake.MockClient{
+					MockNewRequest: fake.NewMockNewRequestFn(nil, nil),
+					MockDo:         fake.NewMockDoFn(errBoom),
+				},
+			},
+			err: errBoom,
+		},
+		"Successful": {
+			reason: "A successful request should not return an error.",
+			cfg: &up.Config{
+				Client: &fake.MockClient{
+					MockNewRequest: fake.NewMockNewRequestFn(nil, nil),
+					MockDo:         fake.NewMockDoFn(nil),
+				},
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			c := NewClient(tc.cfg)
+			err := c.RemoveMember(context.Background(), 99999, 9999)
+			if diff := cmp.Diff(tc.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nRemoveMember(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestDeleteInvite(t *testing.T) {
+	errBoom := errors.New("boom")
+
+	cases := map[string]struct {
+		reason string
+		cfg    *up.Config
+		err    error
+	}{
+		"NewRequestFailed": {
+			reason: "Failing to construct a request should return an error.",
+			cfg: &up.Config{
+				Client: &fake.MockClient{
+					MockNewRequest: fake.NewMockNewRequestFn(nil, errBoom),
+				},
+			},
+			err: errBoom,
+		},
+		"DoFailed": {
+			reason: "Failing to execute request should return an error.",
+			cfg: &up.Config{
+				Client: &fake.MockClient{
+					MockNewRequest: fake.NewMockNewRequestFn(nil, nil),
+					MockDo:         fake.NewMockDoFn(errBoom),
+				},
+			},
+			err: errBoom,
+		},
+		"Successful": {
+			reason: "A successful request should not return an error.",
+			cfg: &up.Config{
+				Client: &fake.MockClient{
+					MockNewRequest: fake.NewMockNewRequestFn(nil, nil),
+					MockDo:         fake.NewMockDoFn(nil),
+				},
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			c := NewClient(tc.cfg)
+			err := c.DeleteInvite(context.Background(), 99999, 9999)
+			if diff := cmp.Diff(tc.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nDeleteInvite(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestCreateInvite(t *testing.T) {
+	errBoom := errors.New("boom")
+
+	cases := map[string]struct {
+		reason string
+		cfg    *up.Config
+		params *OrganizationInviteCreateParameters
+		err    error
+	}{
+		"NewRequestFailed": {
+			reason: "Failing to construct a request should return an error.",
+			cfg: &up.Config{
+				Client: &fake.MockClient{
+					MockNewRequest: fake.NewMockNewRequestFn(nil, errBoom),
+				},
+			},
+			err: errBoom,
+		},
+		"DoFailed": {
+			reason: "Failing to execute request should return an error.",
+			cfg: &up.Config{
+				Client: &fake.MockClient{
+					MockNewRequest: fake.NewMockNewRequestFn(nil, nil),
+					MockDo:         fake.NewMockDoFn(errBoom),
+				},
+			},
+			err: errBoom,
+		},
+		"Successful": {
+			reason: "A successful request should not return an error.",
+			cfg: &up.Config{
+				Client: &fake.MockClient{
+					MockNewRequest: fake.NewMockNewRequestFn(nil, nil),
+					MockDo:         fake.NewMockDoFn(nil),
+				},
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			c := NewClient(tc.cfg)
+			err := c.CreateInvite(context.Background(), 9999, tc.params)
+			if diff := cmp.Diff(tc.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nCreateInvite(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestListMembers(t *testing.T) {
+	errBoom := errors.New("boom")
+	testURL, _ := url.Parse("https://localhost:8080")
+	var id uint = 999
+	type args struct {
+		org uint
+	}
+	cases := map[string]struct {
+		reason string
+		args   args
+		cfg    *up.Config
+		want   []Member
+		err    error
+	}{
+		"NewRequestFailed": {
+			reason: "Failing to construct a request should return an error.",
+			args: args{
+				org: id,
+			},
+			cfg: &up.Config{
+				Client: &fake.MockClient{
+					MockNewRequest: fake.NewMockNewRequestFn(nil, errBoom),
+				},
+			},
+			err: errBoom,
+		},
+		"DoFailed": {
+			reason: "Failing to execute request should return an error.",
+			args: args{
+				org: id,
+			},
+			cfg: &up.Config{
+				Client: &fake.MockClient{
+					MockNewRequest: func(ctx context.Context, method, prefix, urlPath string, body interface{}) (*http.Request, error) {
+						if method != http.MethodGet {
+							t.Errorf("unexpected method: %s", method)
+						}
+						if prefix != basePath {
+							t.Errorf("unexpected prefix: %s", method)
+						}
+						if urlPath != path.Join(strconv.FormatUint(uint64(id), 10), "members") {
+							t.Errorf("unexpected path: %s", urlPath)
+						}
+						r, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, testURL.String(), nil)
+						return r, nil
+					},
+					MockDo: func(req *http.Request, _ interface{}) error {
+						if req.URL.Host != testURL.Host {
+							t.Errorf("unexpected host: %s", req.URL.Host)
+						}
+						return errBoom
+					},
+				},
+			},
+			err: errBoom,
+		},
+		"Successful": {
+			reason: "A successful request should not return an error.",
+			args: args{
+				org: id,
+			},
+			cfg: &up.Config{
+				Client: &fake.MockClient{
+					MockNewRequest: func(ctx context.Context, method, prefix, urlPath string, body interface{}) (*http.Request, error) {
+						if method != http.MethodGet {
+							t.Errorf("unexpected method: %s", method)
+						}
+						if prefix != basePath {
+							t.Errorf("unexpected prefix: %s", method)
+						}
+						if urlPath != path.Join(strconv.FormatUint(uint64(id), 10), "members") {
+							t.Errorf("unexpected path: %s", urlPath)
+						}
+						r, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, testURL.String(), nil)
+						return r, nil
+					},
+					MockDo: func(req *http.Request, _ interface{}) error {
+						if req.URL.Host != testURL.Host {
+							t.Errorf("unexpected host: %s", req.URL.Host)
+						}
+						return nil
+					},
+				},
+			},
+			want: []Member{},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			c := NewClient(tc.cfg)
+			res, err := c.ListMembers(context.Background(), tc.args.org)
+			if diff := cmp.Diff(tc.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nListMembers(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want, res); diff != "" {
+				t.Errorf("\n%s\nListMembers(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestListInvites(t *testing.T) {
+	errBoom := errors.New("boom")
+	testURL, _ := url.Parse("https://localhost:8080")
+	var id uint = 999
+	type args struct {
+		org uint
+	}
+	cases := map[string]struct {
+		reason string
+		args   args
+		cfg    *up.Config
+		want   []Invite
+		err    error
+	}{
+		"NewRequestFailed": {
+			reason: "Failing to construct a request should return an error.",
+			args: args{
+				org: id,
+			},
+			cfg: &up.Config{
+				Client: &fake.MockClient{
+					MockNewRequest: fake.NewMockNewRequestFn(nil, errBoom),
+				},
+			},
+			err: errBoom,
+		},
+		"DoFailed": {
+			reason: "Failing to execute request should return an error.",
+			args: args{
+				org: id,
+			},
+			cfg: &up.Config{
+				Client: &fake.MockClient{
+					MockNewRequest: func(ctx context.Context, method, prefix, urlPath string, body interface{}) (*http.Request, error) {
+						if method != http.MethodGet {
+							t.Errorf("unexpected method: %s", method)
+						}
+						if prefix != basePath {
+							t.Errorf("unexpected prefix: %s", method)
+						}
+						if urlPath != path.Join(strconv.FormatUint(uint64(id), 10), "invites") {
+							t.Errorf("unexpected path: %s", urlPath)
+						}
+						r, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, testURL.String(), nil)
+						return r, nil
+					},
+					MockDo: func(req *http.Request, _ interface{}) error {
+						if req.URL.Host != testURL.Host {
+							t.Errorf("unexpected host: %s", req.URL.Host)
+						}
+						return errBoom
+					},
+				},
+			},
+			err: errBoom,
+		},
+		"Successful": {
+			reason: "A successful request should not return an error.",
+			args: args{
+				org: id,
+			},
+			cfg: &up.Config{
+				Client: &fake.MockClient{
+					MockNewRequest: func(ctx context.Context, method, prefix, urlPath string, body interface{}) (*http.Request, error) {
+						if method != http.MethodGet {
+							t.Errorf("unexpected method: %s", method)
+						}
+						if prefix != basePath {
+							t.Errorf("unexpected prefix: %s", method)
+						}
+						if urlPath != path.Join(strconv.FormatUint(uint64(id), 10), "invites") {
+							t.Errorf("unexpected path: %s", urlPath)
+						}
+						r, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, testURL.String(), nil)
+						return r, nil
+					},
+					MockDo: func(req *http.Request, _ interface{}) error {
+						if req.URL.Host != testURL.Host {
+							t.Errorf("unexpected host: %s", req.URL.Host)
+						}
+						return nil
+					},
+				},
+			},
+			want: []Invite{},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			c := NewClient(tc.cfg)
+			res, err := c.ListInvites(context.Background(), tc.args.org)
+			if diff := cmp.Diff(tc.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nListInvites(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want, res); diff != "" {
+				t.Errorf("\n%s\nListInvites(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/service/organizations/types.go
+++ b/service/organizations/types.go
@@ -56,3 +56,29 @@ type OrganizationCreateParameters struct {
 	Name        string `json:"name"`
 	DisplayName string `json:"displayName"`
 }
+
+// User is a user on Upbound.
+type User struct {
+	ID   uint   `json:"id"`
+	Name string `json:"name"`
+}
+
+// Member is a member of an organization.
+type Member struct {
+	Permission OrganizationPermissionGroup `json:"permission"`
+	User       User                        `json:"user"`
+}
+
+// Invite is a pending organization member.
+type Invite struct {
+	ID         uint                        `json:"id"`
+	Email      string                      `json:"email"`
+	Permission OrganizationPermissionGroup `json:"permission"`
+	CreatedAt  string                      `json:"createdAt"`
+}
+
+// OrganizationInviteCreateParameters are the parameters for creating a user invite to an organization.
+type OrganizationInviteCreateParameters struct {
+	Email      string                      `json:"email"`
+	Permission OrganizationPermissionGroup `json:"organizationPermission"`
+}


### PR DESCRIPTION
Needed for https://github.com/upbound/up/issues/285, supports the following PR: https://github.com/upbound/up/pull/286

This uses the `api.upbound.io/v1/organizations/:organization_id/` REST API

It supports managing members as well as invites for new members

Signed-off-by: Julien Duchesne <julien.duchesne@grafana.com>
