### PR TITLE
consume new error struct from shimmer

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -16,37 +16,20 @@ package errors
 
 import (
 	"fmt"
+	"net/http"
 )
 
 var _ error = &Error{}
 
-// ErrorType indicates the type of error.
-type ErrorType string
-
-// Upbound SDK error types.
-const (
-	ErrorTypeForbidden    ErrorType = "Forbidden"
-	ErrorTypeNotFound     ErrorType = "NotFound"
-	ErrorTypeUnauthorized ErrorType = "Unauthorized"
-	ErrorTypeUnknown      ErrorType = "Unknown"
-)
-
-// Error is an Upbound SDK error.
+// Error is an Upbound SDK error response.
 type Error struct {
-	Response ErrorResponse
-	Type     ErrorType
-	Message  string
-}
-
-// ErrorResponse is an Upbound SDK error response.
-type ErrorResponse struct {
 	Status int     `json:"status"`
 	Title  string  `json:"title"`
 	Detail *string `json:"detail,omitempty"`
 }
 
 // Error returns the error message with the underlying error.
-func (e *ErrorResponse) Error() string {
+func (e *Error) Error() string {
 	detail := ""
 	if e.Detail != nil {
 		detail = fmt.Sprintf(": %s", *e.Detail)
@@ -54,24 +37,10 @@ func (e *ErrorResponse) Error() string {
 	return fmt.Sprintf("%s%s", e.Title, detail)
 }
 
-// Error returns the error message with the underlying error.
-func (e *Error) Error() string {
-	return fmt.Sprintf("%s: %s", e.Message, e.Response.Error())
-}
-
 // IsNotFound returns true if the error type is ErrorTypeNotFound, and false
 // otherwise.
 func (e *Error) IsNotFound() bool {
-	return e.Type == ErrorTypeNotFound
-}
-
-// New constructs a new Upbound SDK error.
-func New(err ErrorResponse, msg string, errType ErrorType) *Error {
-	return &Error{
-		Response: err,
-		Type:     errType,
-		Message:  msg,
-	}
+	return e.Status == http.StatusNotFound
 }
 
 // IsNotFound returns true if the error is an Upbound SDK NotFound error, and

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -33,14 +33,30 @@ const (
 
 // Error is an Upbound SDK error.
 type Error struct {
-	Err     error
-	Type    ErrorType
-	Message string
+	Response ErrorResponse
+	Type     ErrorType
+	Message  string
+}
+
+// ErrorResponse is an Upbound SDK error response.
+type ErrorResponse struct {
+	Status int     `json:"status"`
+	Title  string  `json:"title"`
+	Detail *string `json:"detail,omitempty"`
+}
+
+// Error returns the error message with the underlying error.
+func (e *ErrorResponse) Error() string {
+	detail := ""
+	if e.Detail != nil {
+		detail = fmt.Sprintf(": %s", *e.Detail)
+	}
+	return fmt.Sprintf("%s%s", e.Title, detail)
 }
 
 // Error returns the error message with the underlying error.
 func (e *Error) Error() string {
-	return fmt.Sprintf("%s: %s", e.Message, e.Err.Error())
+	return fmt.Sprintf("%s: %s", e.Message, e.Response.Error())
 }
 
 // IsNotFound returns true if the error type is ErrorTypeNotFound, and false
@@ -50,11 +66,11 @@ func (e *Error) IsNotFound() bool {
 }
 
 // New constructs a new Upbound SDK error.
-func New(err error, msg string, errType ErrorType) *Error {
+func New(err ErrorResponse, msg string, errType ErrorType) *Error {
 	return &Error{
-		Err:     err,
-		Type:    errType,
-		Message: msg,
+		Response: err,
+		Type:     errType,
+		Message:  msg,
 	}
 }
 

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -15,6 +15,7 @@
 package errors
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -29,15 +30,13 @@ func TestIsNotFound(t *testing.T) {
 	}{
 		"TestNotErrIsNotFound": {
 			reason: "Error with type other than ErrorTypeNotFound should return false.",
-			err: &Error{
-				Type: ErrorTypeUnknown,
-			},
-			want: false,
+			err:    &Error{Status: http.StatusInternalServerError, Title: http.StatusText(http.StatusInternalServerError)},
+			want:   false,
 		},
 		"TestIsErrIsNotFound": {
 			reason: "Error with type ErrorTypeNotFound should return true.",
 			err: &Error{
-				Type: ErrorTypeNotFound,
+				Status: http.StatusNotFound,
 			},
 			want: true,
 		},


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes
Consumes new error struct of response body from shimmer providing additional details about error when available.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes #35 [154](https://github.com/upbound/squad-marketplace/issues/154)

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested
Tested with locally built `up` against new error returning services in `DEV`:
```
> up repo create test-
up: error: Repository name does not meet constraints: Repository name must be between 1 and 63 characters long, must begin with at least one lowercase alphanumeric character, may not end in a hyphen and may not contain consecutive hyphens.
> up repo create test
daren/test created
> up repo create test-test
up: error: Repository Limit Exceeded: You've reached your repository limit on this account.
```
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
