### PR TITLE
Introduce new configurations package

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -18,7 +18,7 @@ jobs:
   # The main gotchas with this action are that it _only_ supports merge commits,
   # and that PRs _must_ be labelled before they're merged to trigger a backport.
   open-pr:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     if: github.event.pull_request.merged
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   detect-noop:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     outputs:
       noop: ${{ steps.noop.outputs.should_skip }}
     steps:
@@ -30,7 +30,7 @@ jobs:
 
 
   lint:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: detect-noop
     if: needs.detect-noop.outputs.noop != 'true'
 
@@ -76,7 +76,7 @@ jobs:
           skip-go-installation: true
 
   check-diff:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: detect-noop
     if: needs.detect-noop.outputs.noop != 'true'
 
@@ -116,7 +116,7 @@ jobs:
         run: make check-diff
 
   unit-tests:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: detect-noop
     if: needs.detect-noop.outputs.noop != 'true'
 

--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -4,7 +4,7 @@ on: issue_comment
 
 jobs:
   points:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     if: startsWith(github.event.comment.body, '/points')
 
     steps:
@@ -65,7 +65,7 @@ jobs:
   # NOTE(negz): See also backport.yml, which is the variant that triggers on PR
   # merge rather than on comment.
   backport:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/backport')
     steps:
     - name: Extract Command

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   create-labels:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   create-tag:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -7,7 +7,11 @@ development and subject to breaking changes.
 
 The following services are currently supported:
 - Accounts
+- Configurations
 - Control Planes
+- Organizations
+- Repositories
+- Robots
 - Tokens
 
 ## Authentication

--- a/service/configurations/client.go
+++ b/service/configurations/client.go
@@ -1,0 +1,65 @@
+// Copyright 2023 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configurations
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/upbound/up-sdk-go"
+)
+
+const (
+	basePath = "v1/configurations"
+)
+
+// Client is a configurations client.
+type Client struct {
+	*up.Config
+}
+
+// NewClient builds a configurations client from the given config.
+func NewClient(cfg *up.Config) *Client {
+	return &Client{cfg}
+}
+
+// List all configurations for an account on Upbound.
+func (c *Client) List(ctx context.Context, account string) (*ConfigurationListResponse, error) {
+	req, err := c.Client.NewRequest(ctx, http.MethodGet, basePath, account, nil)
+	if err != nil {
+		return nil, err
+	}
+	configurations := &ConfigurationListResponse{}
+	err = c.Client.Do(req, &configurations)
+	if err != nil {
+		return nil, err
+	}
+	return configurations, nil
+}
+
+// Get a configuration for an account by name on Upbound.
+func (c *Client) Get(ctx context.Context, account, name string) (*ConfigurationResponse, error) {
+	req, err := c.Client.NewRequest(ctx, http.MethodGet, basePath, fmt.Sprintf("%s/%s", account, name), nil)
+	if err != nil {
+		return nil, err
+	}
+	configuration := &ConfigurationResponse{}
+	err = c.Client.Do(req, &configuration)
+	if err != nil {
+		return nil, err
+	}
+	return configuration, nil
+}

--- a/service/configurations/client_test.go
+++ b/service/configurations/client_test.go
@@ -1,0 +1,239 @@
+// Copyright 2023 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configurations
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"path"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/pkg/errors"
+
+	"github.com/upbound/up-sdk-go"
+	"github.com/upbound/up-sdk-go/fake"
+)
+
+func TestList(t *testing.T) {
+	errBoom := errors.New("boom")
+	testURL, _ := url.Parse("https://localhost:8080")
+	var account string = "someaccount"
+	type args struct {
+		account string
+	}
+	testCases := map[string]struct {
+		reason string
+		args   args
+		cfg    *up.Config
+		want   *ConfigurationListResponse
+		err    error
+	}{
+		"NewRequestFailed": {
+			reason: "Failing to construct a request should return an error.",
+			args: args{
+				account: account,
+			},
+			cfg: &up.Config{
+				Client: &fake.MockClient{
+					MockNewRequest: fake.NewMockNewRequestFn(nil, errBoom),
+				},
+			},
+			err: errBoom,
+		},
+		"DoFailed": {
+			reason: "Failing to execute request should return an error.",
+			args: args{
+				account: account,
+			},
+			cfg: &up.Config{
+				Client: &fake.MockClient{
+					MockNewRequest: func(ctx context.Context, method, prefix, urlPath string, body interface{}) (*http.Request, error) {
+						if method != http.MethodGet {
+							t.Errorf("unexpected method: %s", method)
+						}
+						if prefix != basePath {
+							t.Errorf("unexpected prefix: %s", method)
+						}
+						if urlPath != account {
+							t.Errorf("unexpected path: %s", urlPath)
+						}
+						r, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, testURL.String(), nil)
+						return r, nil
+					},
+					MockDo: func(req *http.Request, _ interface{}) error {
+						if req.URL.Host != testURL.Host {
+							t.Errorf("unexpected host: %s", req.URL.Host)
+						}
+						return errBoom
+					},
+				},
+			},
+			err: errBoom,
+		},
+		"Successful": {
+			reason: "A successful request should not return an error.",
+			args: args{
+				account: account,
+			},
+			cfg: &up.Config{
+				Client: &fake.MockClient{
+					MockNewRequest: func(ctx context.Context, method, prefix, urlPath string, body interface{}) (*http.Request, error) {
+						if method != http.MethodGet {
+							t.Errorf("unexpected method: %s", method)
+						}
+						if prefix != basePath {
+							t.Errorf("unexpected prefix: %s", method)
+						}
+						if urlPath != account {
+							t.Errorf("unexpected path: %s", urlPath)
+						}
+						r, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, testURL.String(), nil)
+						return r, nil
+					},
+					MockDo: func(req *http.Request, _ interface{}) error {
+						if req.URL.Host != testURL.Host {
+							t.Errorf("unexpected host: %s", req.URL.Host)
+						}
+						return nil
+					},
+				},
+			},
+			want: &ConfigurationListResponse{},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			c := NewClient(tc.cfg)
+			res, err := c.List(context.Background(), tc.args.account)
+			if diff := cmp.Diff(tc.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nList(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want, res); diff != "" {
+				t.Errorf("\n%s\nList(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestGet(t *testing.T) {
+	errBoom := errors.New("boom")
+	testURL, _ := url.Parse("https://localhost:8080")
+	var account string = "someaccount"
+	var name string = "someconfiguration"
+	type args struct {
+		account string
+		name    string
+	}
+	testCases := map[string]struct {
+		reason string
+		args   args
+		cfg    *up.Config
+		want   *ConfigurationResponse
+		err    error
+	}{
+		"NewRequestFailed": {
+			reason: "Failing to construct a request should return an error.",
+			args: args{
+				account: account,
+				name:    name,
+			},
+			cfg: &up.Config{
+				Client: &fake.MockClient{
+					MockNewRequest: fake.NewMockNewRequestFn(nil, errBoom),
+				},
+			},
+			err: errBoom,
+		},
+		"DoFailed": {
+			reason: "Failing to execute request should return an error.",
+			args: args{
+				account: account,
+				name:    name,
+			},
+			cfg: &up.Config{
+				Client: &fake.MockClient{
+					MockNewRequest: func(ctx context.Context, method, prefix, urlPath string, body interface{}) (*http.Request, error) {
+						if method != http.MethodGet {
+							t.Errorf("unexpected method: %s", method)
+						}
+						if prefix != basePath {
+							t.Errorf("unexpected prefix: %s", method)
+						}
+						if urlPath != path.Join(account, name) {
+							t.Errorf("unexpected path: %s", urlPath)
+						}
+						r, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, testURL.String(), nil)
+						return r, nil
+					},
+					MockDo: func(req *http.Request, _ interface{}) error {
+						if req.URL.Host != testURL.Host {
+							t.Errorf("unexpected host: %s", req.URL.Host)
+						}
+						return errBoom
+					},
+				},
+			},
+			err: errBoom,
+		},
+		"Successful": {
+			reason: "A successful request should not return an error.",
+			args: args{
+				account: account,
+				name:    name,
+			},
+			cfg: &up.Config{
+				Client: &fake.MockClient{
+					MockNewRequest: func(ctx context.Context, method, prefix, urlPath string, body interface{}) (*http.Request, error) {
+						if method != http.MethodGet {
+							t.Errorf("unexpected method: %s", method)
+						}
+						if prefix != basePath {
+							t.Errorf("unexpected prefix: %s", method)
+						}
+						if urlPath != path.Join(account, name) {
+							t.Errorf("unexpected path: %s", urlPath)
+						}
+						r, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, testURL.String(), nil)
+						return r, nil
+					},
+					MockDo: func(req *http.Request, _ interface{}) error {
+						if req.URL.Host != testURL.Host {
+							t.Errorf("unexpected host: %s", req.URL.Host)
+						}
+						return nil
+					},
+				},
+			},
+			want: &ConfigurationResponse{},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			c := NewClient(tc.cfg)
+			res, err := c.Get(context.Background(), tc.args.account, tc.args.name)
+			if diff := cmp.Diff(tc.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nGet(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want, res); diff != "" {
+				t.Errorf("\n%s\nGet(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/service/configurations/types.go
+++ b/service/configurations/types.go
@@ -20,7 +20,7 @@ import (
 	"github.com/google/uuid"
 )
 
-// ConfigurationResponse represents the concept of a Configuration Upbound.
+// ConfigurationResponse represents the concept of a Configuration on Upbound.
 // It is used to configure a Managed Control Plane with a set of API types
 // and optional extensions.
 type ConfigurationResponse struct {

--- a/service/configurations/types.go
+++ b/service/configurations/types.go
@@ -1,0 +1,44 @@
+// Copyright 2023 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configurations
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ConfigurationResponse represents the concept of a Configuration Upbound.
+// It is used to configure a Managed Control Plane with a set of API types
+// and optional extensions.
+type ConfigurationResponse struct {
+	ID            uuid.UUID  `json:"id"`
+	Name          *string    `json:"name"`
+	LatestVersion *string    `json:"latestVersion,omitempty"`
+	TemplateID    string     `json:"templateID"`
+	Provider      string     `json:"provider"`
+	Context       string     `json:"context"`
+	Repo          string     `json:"repo"`
+	Branch        string     `json:"branch"`
+	CreatorID     uint       `json:"creatorId"`
+	CreatedAt     time.Time  `json:"createdAt"`
+	UpdatedAt     *time.Time `json:"updatedAt,omitempty"`
+	SyncedAt      *time.Time `json:"syncedAt,omitempty"`
+}
+
+// ConfigurationListResponse is a list of all configurations belonging to the account.
+type ConfigurationListResponse struct {
+	Configurations []ConfigurationResponse `json:"configurations"`
+}


### PR DESCRIPTION

<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes
This PR supports two new GET service endpoints for Upbound root configurations.

`GET /v1/configurations/{accountName}`
`GET /v1/configurations/{accountName}/{cfgName}`

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested
- adapted some of the examples in this repository for `Get` and `List` Configurations
