### PR TITLE
Add support for creating configurations and querying the gitsources l…

### DIFF
--- a/client.go
+++ b/client.go
@@ -126,7 +126,7 @@ func (c *HTTPClient) Do(req *http.Request, obj interface{}) error {
 	return nil
 }
 
-// Do performs an HTTP request and returns the full response.
+// DoRaw performs an HTTP request and returns the full response.
 // This is useful for clients that need to read headers and/or the
 // HTTP status code.
 func (c *HTTPClient) DoRaw(req *http.Request) (*http.Response, string, error) {

--- a/client.go
+++ b/client.go
@@ -126,22 +126,6 @@ func (c *HTTPClient) Do(req *http.Request, obj interface{}) error {
 	return nil
 }
 
-// DoRaw performs an HTTP request and returns the full response.
-// This is useful for clients that need to read headers and/or the
-// HTTP status code.
-func (c *HTTPClient) DoRaw(req *http.Request) (*http.Response, string, error) {
-	res, err := c.HTTP.Do(req)
-	if err != nil {
-		return nil, "", err
-	}
-	defer res.Body.Close() // nolint:errcheck
-	b, err := io.ReadAll(res.Body)
-	if err != nil {
-		return nil, "", err
-	}
-	return res, string(b), err
-}
-
 // handleErrors invokes the underlying response error handler.
 func (c *HTTPClient) handleErrors(res *http.Response) error {
 	return c.ErrorHandler.Handle(res)

--- a/client.go
+++ b/client.go
@@ -126,6 +126,22 @@ func (c *HTTPClient) Do(req *http.Request, obj interface{}) error {
 	return nil
 }
 
+// Do performs an HTTP request and returns the full response.
+// This is useful for clients that need to read headers and/or the
+// HTTP status code.
+func (c *HTTPClient) DoRaw(req *http.Request) (*http.Response, string, error) {
+	res, err := c.HTTP.Do(req)
+	if err != nil {
+		return nil, "", err
+	}
+	defer res.Body.Close() // nolint:errcheck
+	b, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, "", err
+	}
+	return res, string(b), err
+}
+
 // handleErrors invokes the underlying response error handler.
 func (c *HTTPClient) handleErrors(res *http.Response) error {
 	return c.ErrorHandler.Handle(res)

--- a/service/configurations/client.go
+++ b/service/configurations/client.go
@@ -67,7 +67,7 @@ func (c *Client) Get(ctx context.Context, account, name string) (*ConfigurationR
 // Create a configuration on Upbound
 // Note that when using GitHub, this will make a new repo, and that requires
 // the GitHub app to be authorized and installed. That's a separate API, which
-// begins with the gitsources login. The full login is implemented in the CLI.
+// begins with the gitsources login. The full login is implemented in the CLI (https://github.com/upbound/up).
 func (c *Client) Create(ctx context.Context, account string, params *ConfigurationCreateParameters) (*ConfigurationResponse, error) {
 	req, err := c.Client.NewRequest(ctx, http.MethodPost, basePath, account, params)
 	if err != nil {

--- a/service/configurations/client.go
+++ b/service/configurations/client.go
@@ -63,3 +63,20 @@ func (c *Client) Get(ctx context.Context, account, name string) (*ConfigurationR
 	}
 	return configuration, nil
 }
+
+// Create a configuration on Upbound
+// Note that when using GitHub, this will make a new repo, and that requires
+// the GitHub app to be authorized and installed. That's a separate API, which
+// begins with the gitsources login. The full login is implemented in the CLI.
+func (c *Client) Create(ctx context.Context, account string, params *ConfigurationCreateParameters) (*ConfigurationResponse, error) {
+	req, err := c.Client.NewRequest(ctx, http.MethodPost, basePath, account, params)
+	if err != nil {
+		return nil, err
+	}
+	configuration := &ConfigurationResponse{}
+	err = c.Client.Do(req, &configuration)
+	if err != nil {
+		return nil, err
+	}
+	return configuration, nil
+}

--- a/service/configurations/client_test.go
+++ b/service/configurations/client_test.go
@@ -237,3 +237,58 @@ func TestGet(t *testing.T) {
 		})
 	}
 }
+
+func TestCreate(t *testing.T) {
+	errBoom := errors.New("boom")
+	account := "upbound"
+	testCases := map[string]struct {
+		reason string
+		cfg    *up.Config
+		params *ConfigurationCreateParameters
+		want   *ConfigurationResponse
+		err    error
+	}{
+		"NewRequestFailed": {
+			reason: "Failing to construct a request should return an error.",
+			cfg: &up.Config{
+				Client: &fake.MockClient{
+					MockNewRequest: fake.NewMockNewRequestFn(nil, errBoom),
+				},
+			},
+			err: errBoom,
+		},
+		"DoFailed": {
+			reason: "Failing to execute request should return an error.",
+			cfg: &up.Config{
+				Client: &fake.MockClient{
+					MockNewRequest: fake.NewMockNewRequestFn(nil, nil),
+					MockDo:         fake.NewMockDoFn(errBoom),
+				},
+			},
+			err: errBoom,
+		},
+		"Successful": {
+			reason: "A successful request should not return an error.",
+			cfg: &up.Config{
+				Client: &fake.MockClient{
+					MockNewRequest: fake.NewMockNewRequestFn(nil, nil),
+					MockDo:         fake.NewMockDoFn(nil),
+				},
+			},
+			want: &ConfigurationResponse{},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			c := NewClient(tc.cfg)
+			res, err := c.Create(context.Background(), account, tc.params)
+			if diff := cmp.Diff(tc.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nCreate(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want, res); diff != "" {
+				t.Errorf("\n%s\nCreate(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/service/configurations/types.go
+++ b/service/configurations/types.go
@@ -20,6 +20,7 @@ import (
 	"github.com/google/uuid"
 )
 
+// Provider is the type of Git provider, such as "github"
 type Provider string
 
 // Tokens can be owned by a user, control plane, or robot.

--- a/service/configurations/types.go
+++ b/service/configurations/types.go
@@ -20,6 +20,13 @@ import (
 	"github.com/google/uuid"
 )
 
+type Provider string
+
+// Tokens can be owned by a user, control plane, or robot.
+const (
+	ProviderGitHub Provider = "github"
+)
+
 // ConfigurationResponse represents the concept of a Configuration on Upbound.
 // It is used to configure a Managed Control Plane with a set of API types
 // and optional extensions.
@@ -28,7 +35,7 @@ type ConfigurationResponse struct {
 	Name          *string    `json:"name"`
 	LatestVersion *string    `json:"latestVersion,omitempty"`
 	TemplateID    string     `json:"templateID"`
-	Provider      string     `json:"provider"`
+	Provider      Provider   `json:"provider"`
 	Context       string     `json:"context"`
 	Repo          string     `json:"repo"`
 	Branch        string     `json:"branch"`
@@ -41,4 +48,13 @@ type ConfigurationResponse struct {
 // ConfigurationListResponse is a list of all configurations belonging to the account.
 type ConfigurationListResponse struct {
 	Configurations []ConfigurationResponse `json:"configurations"`
+}
+
+// ConfigurationCreateParameters are the parameters for creating a control plane.
+type ConfigurationCreateParameters struct {
+	Context    string   `json:"context"`    // Name of the GitHub account/org
+	Name       string   `json:"name"`       // Name of the configuration
+	Provider   Provider `json:"provider"`   // See Provider above
+	Repo       string   `json:"repo"`       // Name of the repo. Usually the same as the configuration name
+	TemplateID string   `json:"templateId"` // Name of the template we clone. There is no API for this today.
 }

--- a/service/gitsources/client.go
+++ b/service/gitsources/client.go
@@ -1,0 +1,76 @@
+// Copyright 2023 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gitsources
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+
+	"github.com/upbound/up-sdk-go"
+)
+
+const (
+	basePath  = "v1/gitSources"
+	loginPath = "github/client/login"
+)
+
+// Client is a gitsources client.
+type Client struct {
+	*up.Config
+}
+
+// NewClient builds a configurations client from the given config.
+func NewClient(cfg *up.Config) *Client {
+	return &Client{cfg}
+}
+
+// Login does a gitsources login.
+func (c *Client) Login(ctx context.Context) (GitsourcesLoginResponse, error) {
+	var loginResponse GitsourcesLoginResponse
+
+	// We have to use the HTTPClient because unlike other Upbound APIs,
+	// the body will be HTML. We need to extract the data we need from
+	// the status code and the headers
+	hc, ok := c.Client.(*up.HTTPClient)
+	if !ok {
+		return loginResponse, errors.New("Unexpected error: client isn't an HTTP client")
+	}
+
+	// The HTTPClient follows redirects, but we don't want that -- we
+	// need to know what the redirect is. The CLI will take different
+	// actions if the redirect goes to github.com (which indicates we
+	// need to login) or Upbound (which indicates we already logged in, or there
+	// is a problem).
+	oldRedirect := hc.HTTP.CheckRedirect
+	hc.HTTP.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+
+	req, err := hc.NewRequest(ctx, http.MethodGet, basePath, loginPath, nil)
+	if err != nil {
+		return loginResponse, err
+	}
+
+	response, _, err := hc.DoRaw(req)
+	hc.HTTP.CheckRedirect = oldRedirect
+	if err != nil {
+		return loginResponse, err
+	}
+	loginResponse.StatusCode = response.StatusCode
+	loginResponse.RedirectUrl, err = url.Parse(response.Header.Get("location"))
+	return loginResponse, err
+}

--- a/service/gitsources/client.go
+++ b/service/gitsources/client.go
@@ -39,8 +39,8 @@ func NewClient(cfg *up.Config) *Client {
 }
 
 // Login does a gitsources login.
-func (c *Client) Login(ctx context.Context) (GitsourcesLoginResponse, error) {
-	var loginResponse GitsourcesLoginResponse
+func (c *Client) Login(ctx context.Context) (LoginResponse, error) {
+	var loginResponse LoginResponse
 
 	// We have to use the HTTPClient because unlike other Upbound APIs,
 	// the body will be HTML. We need to extract the data we need from
@@ -65,12 +65,12 @@ func (c *Client) Login(ctx context.Context) (GitsourcesLoginResponse, error) {
 		return loginResponse, err
 	}
 
-	response, _, err := hc.DoRaw(req)
+	response, _, err := hc.DoRaw(req) //nolint:bodyclose
 	hc.HTTP.CheckRedirect = oldRedirect
 	if err != nil {
 		return loginResponse, err
 	}
 	loginResponse.StatusCode = response.StatusCode
-	loginResponse.RedirectUrl, err = url.Parse(response.Header.Get("location"))
+	loginResponse.RedirectURL, err = url.Parse(response.Header.Get("location"))
 	return loginResponse, err
 }

--- a/service/gitsources/client.go
+++ b/service/gitsources/client.go
@@ -65,11 +65,12 @@ func (c *Client) Login(ctx context.Context) (LoginResponse, error) {
 		return loginResponse, err
 	}
 
-	response, _, err := hc.DoRaw(req) //nolint:bodyclose
+	response, err := hc.HTTP.Do(req)
 	hc.HTTP.CheckRedirect = oldRedirect
 	if err != nil {
 		return loginResponse, err
 	}
+	defer response.Body.Close() // nolint:errcheck
 	loginResponse.StatusCode = response.StatusCode
 	loginResponse.RedirectURL, err = url.Parse(response.Header.Get("location"))
 	return loginResponse, err

--- a/service/gitsources/types.go
+++ b/service/gitsources/types.go
@@ -1,0 +1,25 @@
+// Copyright 2023 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gitsources
+
+import (
+	"net/url"
+)
+
+// GitsourcesLoginResponse represents the information we get when we do a gitsources login.
+type GitsourcesLoginResponse struct {
+	RedirectUrl *url.URL
+	StatusCode  int
+}

--- a/service/gitsources/types.go
+++ b/service/gitsources/types.go
@@ -18,8 +18,8 @@ import (
 	"net/url"
 )
 
-// GitsourcesLoginResponse represents the information we get when we do a gitsources login.
-type GitsourcesLoginResponse struct {
-	RedirectUrl *url.URL
+// LoginResponse represents the information we get when we do a gitsources login.
+type LoginResponse struct {
+	RedirectURL *url.URL
 	StatusCode  int
 }


### PR DESCRIPTION
### Description
Add support for creating configurations and querying the gitsources login API

* Add new API: Create Configuration
* Add new API: v1/gitSources/github/client/login (used for authorizing & installing GitHub apps)

### How has this code been tested

* Unit tests for the Create Configuration API
* Manual testing within the CLI for both new APIs. 
