### PR TITLE
Add configuration delete and update control plane response to include configuration information.

### DIFF
--- a/service/configurations/client.go
+++ b/service/configurations/client.go
@@ -80,3 +80,15 @@ func (c *Client) Create(ctx context.Context, account string, params *Configurati
 	}
 	return configuration, nil
 }
+
+// Delete a configuration on an Upbound account by name.
+// This operation can potentially orphan Managed Control Planes that have deployed
+// the configuration, as they can no longer update them. The API will return an
+// HTTP 403 status code in this case indicating that the configuration is still in use.
+func (c *Client) Delete(ctx context.Context, account, name string) error {
+	req, err := c.Client.NewRequest(ctx, http.MethodDelete, basePath, fmt.Sprintf("%s/%s", account, name), nil)
+	if err != nil {
+		return err
+	}
+	return c.Client.Do(req, nil)
+}

--- a/service/configurations/client_test.go
+++ b/service/configurations/client_test.go
@@ -292,3 +292,66 @@ func TestCreate(t *testing.T) {
 		})
 	}
 }
+
+func TestDelete(t *testing.T) {
+	errBoom := errors.New("boom")
+	var account string = "someaccount"
+	var name string = "someconfiguration"
+	type args struct {
+		account string
+		name    string
+	}
+
+	testCases := map[string]struct {
+		reason string
+		args   args
+		cfg    *up.Config
+		err    error
+	}{
+		"NewRequestFailed": {
+			reason: "Failing to construct a request should return an error.",
+			args: args{
+				account: account,
+				name:    name,
+			},
+			cfg: &up.Config{
+				Client: &fake.MockClient{
+					MockNewRequest: fake.NewMockNewRequestFn(nil, errBoom),
+				},
+			},
+			err: errBoom,
+		},
+		"DoFailed": {
+			reason: "Failing to execute request should return an error.",
+			args: args{
+				account: account,
+				name:    name,
+			},
+			cfg: &up.Config{
+				Client: &fake.MockClient{
+					MockNewRequest: fake.NewMockNewRequestFn(nil, nil),
+					MockDo:         fake.NewMockDoFn(errBoom),
+				},
+			},
+			err: errBoom,
+		},
+		"Successful": {
+			reason: "A successful request should not return an error.",
+			cfg: &up.Config{
+				Client: &fake.MockClient{
+					MockNewRequest: fake.NewMockNewRequestFn(nil, nil),
+					MockDo:         fake.NewMockDoFn(nil),
+				},
+			},
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(*testing.T) {
+			c := NewClient(tc.cfg)
+			err := c.Delete(context.Background(), tc.args.account, tc.args.name)
+			if diff := cmp.Diff(tc.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nDelete(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/service/controlplanes/types.go
+++ b/service/controlplanes/types.go
@@ -33,14 +33,15 @@ const (
 
 // ControlPlane describes a control plane.
 type ControlPlane struct {
-	ID          uuid.UUID  `json:"id,omitempty"`
-	Name        string     `json:"name,omitempty"`
-	Description string     `json:"description,omitempty"`
-	CreatorID   uint       `json:"creatorId,omitempty"`
-	Reserved    bool       `json:"reserved"`
-	CreatedAt   *time.Time `json:"createdAt,omitempty"`
-	UpdatedAt   *time.Time `json:"updatedAt,omitempty"`
-	ExpiresAt   time.Time  `json:"expiresAt"`
+	ID            uuid.UUID                 `json:"id,omitempty"`
+	Name          string                    `json:"name,omitempty"`
+	Description   string                    `json:"description,omitempty"`
+	CreatorID     uint                      `json:"creatorId,omitempty"`
+	Reserved      bool                      `json:"reserved"`
+	CreatedAt     *time.Time                `json:"createdAt,omitempty"`
+	UpdatedAt     *time.Time                `json:"updatedAt,omitempty"`
+	ExpiresAt     time.Time                 `json:"expiresAt"`
+	Configuration ControlPlaneConfiguration `json:"configuration"`
 }
 
 // PermissionGroup describes control plane permissions for the authenticated
@@ -77,6 +78,35 @@ type ControlPlaneListResponse struct {
 
 // ControlPlaneCreateParameters are the parameters for creating a control plane.
 type ControlPlaneCreateParameters struct {
-	Name        string `json:"name"`
-	Description string `json:"description"`
+	ConfigurationID uuid.UUID `json:"configurationId"`
+	Name            string    `json:"name"`
+	Description     string    `json:"description"`
+}
+
+// ConfigurationStatus represents the different states of a Configuration relative to a Managed Control Plane.
+type ConfigurationStatus string
+
+const (
+	// ConfigurationInstallationQueued means queued to begin installation in a Managed Control Plane
+	ConfigurationInstallationQueued ConfigurationStatus = "installationQueued"
+	// ConfigurationUpgradeQueued means queued to upgrade to a specified version in a Managed Control Plane
+	ConfigurationUpgradeQueued ConfigurationStatus = "upgradeQueued"
+	// ConfigurationInstalling means currently installing into the Managed Control Plane
+	ConfigurationInstalling ConfigurationStatus = "installing"
+	// ConfigurationReady means ready for use in the Managed Control Plane
+	ConfigurationReady ConfigurationStatus = "ready"
+	// ConfigurationUpgrading means currently upgrading to a specified version in the Managed Control Plane
+	ConfigurationUpgrading ConfigurationStatus = "upgrading"
+)
+
+// ControlPlaneConfiguration represents an instance of a Configuration associated with a
+// Managed Control Plane on Upbound.
+type ControlPlaneConfiguration struct {
+	ID             uuid.UUID           `json:"id"`
+	Name           *string             `json:"name"`
+	CurrentVersion *string             `json:"currentVersion"`
+	DesiredVersion *string             `json:"desiredVersion"`
+	Status         ConfigurationStatus `json:"status"`
+	SyncedAt       *time.Time          `json:"syncedAt,omitempty"`
+	DeployedAt     *time.Time          `json:"deployedAt,omitempty"`
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes
In anticipation of all managed control planes on Upbound requiring a Configuration to be installed, this change also updates the control plane creation parameters to include a configuration ID.

This preempts some changes in the API to return specific statuses/error responses (for example, a 403 when attempting to delete an in-use Configuration, or a Bad Request if configuration ID is not specified).

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
- adapted the examples in `_example` to test against the public API.