### PR TITLE
Add userinfo client

### DIFF
--- a/_examples/userinfo/main.go
+++ b/_examples/userinfo/main.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"os"
+
+	"github.com/upbound/up-sdk-go"
+	"github.com/upbound/up-sdk-go/service/userinfo"
+)
+
+// Gets information for the logged in user.
+func main() {
+	// Prompt for auth input
+	fmt.Println("Enter username: ")
+	var user string
+	fmt.Scanln(&user)
+	fmt.Println("Enter password: ")
+	var password string
+	fmt.Scanln(&password)
+
+	var api string
+	if api = os.Getenv("UP_ENDPOINT"); api == "" {
+		api = "https://api.upbound.io"
+	}
+
+	base, _ := url.Parse(api)
+	cj, err := cookiejar.New(nil)
+	if err != nil {
+		panic(err)
+	}
+	upClient := up.NewClient(func(c *up.HTTPClient) {
+		c.BaseURL = base
+		c.HTTP = &http.Client{
+			Jar: cj,
+		}
+	})
+	cfg := up.NewConfig(func(cfg *up.Config) {
+		cfg.Client = upClient
+	})
+	auth := &struct {
+		ID       string `json:"id"`
+		Password string `json:"password"`
+	}{
+		ID:       user,
+		Password: password,
+	}
+	jsonStr, err := json.Marshal(auth)
+	if err != nil {
+		panic(err)
+	}
+	u, err := base.Parse("/v1/login")
+	if err != nil {
+		panic(err)
+	}
+	req, err := http.NewRequest(http.MethodPost, u.String(), bytes.NewReader(jsonStr))
+	if err != nil {
+		panic(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if err = cfg.Client.Do(req, nil); err != nil {
+		panic(err)
+	}
+	client := userinfo.NewClient(cfg)
+	fmt.Println("Getting user info...")
+	res, err := client.Get(context.Background())
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(res.User.Username)
+}

--- a/service/userinfo/client.go
+++ b/service/userinfo/client.go
@@ -1,0 +1,51 @@
+// Copyright 2023 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package userinfo
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/upbound/up-sdk-go"
+)
+
+const (
+	basePath = "v1/self"
+)
+
+// Client is a user info client.
+type Client struct {
+	*up.Config
+}
+
+// NewClient builds a user info client from the passed config.
+func NewClient(cfg *up.Config) *Client {
+	return &Client{
+		cfg,
+	}
+}
+
+// Get gets user information on Upbound.
+func (c *Client) Get(ctx context.Context) (*Response, error) { // nolint:interfacer
+	req, err := c.Client.NewRequest(ctx, http.MethodGet, basePath, "", nil)
+	if err != nil {
+		return nil, err
+	}
+	r := &Response{}
+	if err := c.Client.Do(req, r); err != nil {
+		return nil, err
+	}
+	return r, nil
+}

--- a/service/userinfo/client.go
+++ b/service/userinfo/client.go
@@ -38,12 +38,12 @@ func NewClient(cfg *up.Config) *Client {
 }
 
 // Get gets user information on Upbound.
-func (c *Client) Get(ctx context.Context) (*Response, error) { // nolint:interfacer
+func (c *Client) Get(ctx context.Context) (*GetResponse, error) { // nolint:interfacer
 	req, err := c.Client.NewRequest(ctx, http.MethodGet, basePath, "", nil)
 	if err != nil {
 		return nil, err
 	}
-	r := &Response{}
+	r := &GetResponse{}
 	if err := c.Client.Do(req, r); err != nil {
 		return nil, err
 	}

--- a/service/userinfo/client_test.go
+++ b/service/userinfo/client_test.go
@@ -1,0 +1,123 @@
+// Copyright 2023 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package userinfo
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/pkg/errors"
+
+	"github.com/upbound/up-sdk-go"
+	"github.com/upbound/up-sdk-go/fake"
+)
+
+func TestGet(t *testing.T) {
+	errBoom := errors.New("boom")
+
+	cases := map[string]struct {
+		reason string
+		cfg    *up.Config
+		want   *GetResponse
+		err    error
+	}{
+		"NewRequestFailed": {
+			reason: "Failing to construct a request should return an error.",
+			cfg: &up.Config{
+				Client: &fake.MockClient{
+					MockNewRequest: func(_ context.Context, method, prefix, urlPath string, body interface{}) (*http.Request, error) {
+						if method != http.MethodGet {
+							t.Errorf("unexpected method: %s", method)
+						}
+						if prefix != basePath {
+							t.Errorf("unexpected prefix: %s", prefix)
+						}
+						if urlPath != "" {
+							t.Errorf("unexpected path: %s", urlPath)
+						}
+						if body != nil {
+							t.Errorf("unexpected body: %v", body)
+						}
+						return nil, errBoom
+					},
+				},
+			},
+			err: errBoom,
+		},
+		"DoFailed": {
+			reason: "Failing to execute request should return an error.",
+			cfg: &up.Config{
+				Client: &fake.MockClient{
+					MockNewRequest: func(_ context.Context, method, prefix, urlPath string, body interface{}) (*http.Request, error) {
+						if method != http.MethodGet {
+							t.Errorf("unexpected method: %s", method)
+						}
+						if prefix != basePath {
+							t.Errorf("unexpected prefix: %s", prefix)
+						}
+						if urlPath != "" {
+							t.Errorf("unexpected path: %s", urlPath)
+						}
+						if body != nil {
+							t.Errorf("unexpected body: %v", body)
+						}
+						return nil, nil
+					},
+					MockDo: fake.NewMockDoFn(errBoom),
+				},
+			},
+			err: errBoom,
+		},
+		"Successful": {
+			reason: "A successful request should not return an error.",
+			cfg: &up.Config{
+				Client: &fake.MockClient{
+					MockNewRequest: func(_ context.Context, method, prefix, urlPath string, body interface{}) (*http.Request, error) {
+						if method != http.MethodGet {
+							t.Errorf("unexpected method: %s", method)
+						}
+						if prefix != basePath {
+							t.Errorf("unexpected prefix: %s", prefix)
+						}
+						if urlPath != "" {
+							t.Errorf("unexpected path: %s", urlPath)
+						}
+						if body != nil {
+							t.Errorf("unexpected body: %v", body)
+						}
+						return nil, nil
+					},
+					MockDo: fake.NewMockDoFn(nil),
+				},
+			},
+			want: &GetResponse{},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			c := NewClient(tc.cfg)
+			res, err := c.Get(context.Background())
+			if diff := cmp.Diff(tc.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nGet(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want, res); diff != "" {
+				t.Errorf("\n%s\nGet(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/service/userinfo/types.go
+++ b/service/userinfo/types.go
@@ -1,0 +1,37 @@
+// Copyright 2023 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package userinfo
+
+import "time"
+
+// Response is information about a user on Upbound.
+type Response struct {
+	Features []string `json:"features"`
+	User     User     `json:"user"`
+}
+
+// User is a user on Upbound.
+type User struct {
+	ID        uint       `json:"id"`
+	Username  string     `json:"username"`
+	FirstName string     `json:"firstName"`
+	LastName  string     `json:"lastName"`
+	Email     string     `json:"email,omitempty"`
+	Biography string     `json:"biography,omitempty"`
+	Location  string     `json:"location,omitempty"`
+	CreatedAt *time.Time `json:"createdAt,omitempty"`
+	UpdatedAt *time.Time `json:"updatedAt,omitempty"`
+	DeletedAt *time.Time `json:"deletedAt,omitempty"`
+}

--- a/service/userinfo/types.go
+++ b/service/userinfo/types.go
@@ -16,8 +16,8 @@ package userinfo
 
 import "time"
 
-// Response is information about a user on Upbound.
-type Response struct {
+// GetResponse is information about a user on Upbound.
+type GetResponse struct {
 	Features []string `json:"features"`
 	User     User     `json:"user"`
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Adds a client that is able to fetch information about the signed in
user.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

```
🤖 (up-sdk-go) go run _examples/userinfo/main.go 
Enter username: 
hasheddan
Enter password: 
[REDACTED]
Getting user info...
hasheddan
```