### PR TITLE
Add control plane specific query parameters

### DIFF
--- a/service/controlplanes/client_test.go
+++ b/service/controlplanes/client_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 
 	"github.com/upbound/up-sdk-go"
@@ -285,6 +286,40 @@ func TestList(t *testing.T) {
 						}
 						if req.URL.Query().Get(common.PageParam) != strconv.FormatInt(50, 10) {
 							t.Errorf("unexpected page: %s", req.URL.Query().Get(common.PageParam))
+						}
+						return nil
+					},
+				},
+			},
+			want: &ControlPlaneListResponse{},
+		},
+		"SuccessfulWithConfiguration": {
+			reason: "A successful request with a Configuration filter should not return an error.",
+			args: args{
+				account: testAccount,
+				opts:    []common.ListOption{common.ListOption(WithConfiguration(uuid.Nil))},
+			},
+			cfg: &up.Config{
+				Client: &fake.MockClient{
+					MockNewRequest: func(ctx context.Context, method, prefix, urlPath string, body interface{}) (*http.Request, error) {
+						if method != http.MethodGet {
+							t.Errorf("unexpected method: %s", method)
+						}
+						if prefix != basePath {
+							t.Errorf("unexpected prefix: %s", method)
+						}
+						if urlPath != testAccount {
+							t.Errorf("unexpected account: %s", urlPath)
+						}
+						r, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, testURL.String(), nil)
+						return r, nil
+					},
+					MockDo: func(req *http.Request, _ interface{}) error {
+						if req.URL.Host != testURL.Host {
+							t.Errorf("unexpected host: %s", req.URL.Host)
+						}
+						if req.URL.Query().Get(ConfigurationIDParam) != uuid.Nil.String() {
+							t.Errorf("unexpected configurationId: %s", req.URL.Query().Get(ConfigurationIDParam))
 						}
 						return nil
 					},

--- a/service/controlplanes/options.go
+++ b/service/controlplanes/options.go
@@ -15,8 +15,9 @@
 package controlplanes
 
 import (
-	"fmt"
 	"net/http"
+
+	"github.com/google/uuid"
 
 	"github.com/upbound/up-sdk-go/service/common"
 )
@@ -30,7 +31,7 @@ const (
 type ControlPlaneListOption common.ListOption
 
 // WithConfiguration sets the configurationId to filter the list response.
-func WithConfiguration(id fmt.Stringer) ControlPlaneListOption {
+func WithConfiguration(id uuid.UUID) ControlPlaneListOption { // nolint:interfacer
 	return func(r *http.Request) {
 		q := r.URL.Query()
 		q.Add(ConfigurationIDParam, id.String())

--- a/service/controlplanes/options.go
+++ b/service/controlplanes/options.go
@@ -1,0 +1,39 @@
+// Copyright 2023 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlplanes
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/upbound/up-sdk-go/service/common"
+)
+
+const (
+	// ConfigurationIDParam is the name of the Configuration UUID query parameter.
+	ConfigurationIDParam = "configurationId"
+)
+
+// ControlPlaneListOption modifies a control plane list request, specifically.
+type ControlPlaneListOption common.ListOption
+
+// WithConfiguration sets the configurationId to filter the list response.
+func WithConfiguration(id fmt.Stringer) ControlPlaneListOption {
+	return func(r *http.Request) {
+		q := r.URL.Query()
+		q.Add(ConfigurationIDParam, id.String())
+		r.URL.RawQuery = q.Encode()
+	}
+}


### PR DESCRIPTION

<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes
Add support for a query parameter that is specific to listing control planes (`?configurationId=STRING`)

This parameter filters the list response to only include control planes that have the specified configuration deployed.

xref https://github.com/upbound/up/pull/298

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested
New unit test, and local testing adapting the `_example`.
