### PR TITLE
Update gitsources login to take port

### DIFF
--- a/service/gitsources/client.go
+++ b/service/gitsources/client.go
@@ -17,6 +17,7 @@ package gitsources
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 
@@ -26,6 +27,7 @@ import (
 const (
 	basePath  = "v1/gitSources"
 	loginPath = "github/client/login"
+	portParam = "cli"
 )
 
 // Client is a gitsources client.
@@ -39,7 +41,7 @@ func NewClient(cfg *up.Config) *Client {
 }
 
 // Login does a gitsources login.
-func (c *Client) Login(ctx context.Context) (LoginResponse, error) {
+func (c *Client) Login(ctx context.Context, port int) (LoginResponse, error) {
 	var loginResponse LoginResponse
 
 	// We have to use the HTTPClient because unlike other Upbound APIs,
@@ -60,7 +62,11 @@ func (c *Client) Login(ctx context.Context) (LoginResponse, error) {
 		return http.ErrUseLastResponse
 	}
 
-	req, err := hc.NewRequest(ctx, http.MethodGet, basePath, loginPath, nil)
+	path := loginPath
+	if port != 0 {
+		path += fmt.Sprintf("?%s=%d", portParam, port)
+	}
+	req, err := hc.NewRequest(ctx, http.MethodGet, basePath, path, nil)
 	if err != nil {
 		return loginResponse, err
 	}


### PR DESCRIPTION
### Description
Update gitsources login to take port

The port is required by the CLI: it's a local port that receives a callback when the authorization and installation of the GitHub app is complete. Clients that don't need the port can pass 0.

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
Manually tested with pending CLI changes against both local-dev and dev. 