### PR TITLE
Add new configuration template API.

### DIFF
--- a/service/configurations/client.go
+++ b/service/configurations/client.go
@@ -23,7 +23,8 @@ import (
 )
 
 const (
-	basePath = "v1/configurations"
+	basePath          = "v1/configurations"
+	templatesBasePath = "v1/configurationTemplates"
 )
 
 // Client is a configurations client.
@@ -91,4 +92,18 @@ func (c *Client) Delete(ctx context.Context, account, name string) error {
 		return err
 	}
 	return c.Client.Do(req, nil)
+}
+
+// ListTemplates all configuration Templates that can be used to make a configuration
+func (c *Client) ListTemplates(ctx context.Context) (*ConfigurationTemplateListResponse, error) {
+	req, err := c.Client.NewRequest(ctx, http.MethodGet, templatesBasePath, "", nil)
+	if err != nil {
+		return nil, err
+	}
+	templates := &ConfigurationTemplateListResponse{}
+	err = c.Client.Do(req, &templates)
+	if err != nil {
+		return nil, err
+	}
+	return templates, nil
 }

--- a/service/configurations/client_test.go
+++ b/service/configurations/client_test.go
@@ -72,7 +72,7 @@ func TestList(t *testing.T) {
 						if urlPath != account {
 							t.Errorf("unexpected path: %s", urlPath)
 						}
-						r, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, testURL.String(), nil)
+						r, _ := http.NewRequestWithContext(ctx, http.MethodGet, testURL.String(), nil)
 						return r, nil
 					},
 					MockDo: func(req *http.Request, _ interface{}) error {
@@ -102,7 +102,7 @@ func TestList(t *testing.T) {
 						if urlPath != account {
 							t.Errorf("unexpected path: %s", urlPath)
 						}
-						r, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, testURL.String(), nil)
+						r, _ := http.NewRequestWithContext(ctx, http.MethodGet, testURL.String(), nil)
 						return r, nil
 					},
 					MockDo: func(req *http.Request, _ interface{}) error {
@@ -178,7 +178,7 @@ func TestGet(t *testing.T) {
 						if urlPath != path.Join(account, name) {
 							t.Errorf("unexpected path: %s", urlPath)
 						}
-						r, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, testURL.String(), nil)
+						r, _ := http.NewRequestWithContext(ctx, http.MethodGet, testURL.String(), nil)
 						return r, nil
 					},
 					MockDo: func(req *http.Request, _ interface{}) error {
@@ -209,7 +209,7 @@ func TestGet(t *testing.T) {
 						if urlPath != path.Join(account, name) {
 							t.Errorf("unexpected path: %s", urlPath)
 						}
-						r, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, testURL.String(), nil)
+						r, _ := http.NewRequestWithContext(ctx, http.MethodGet, testURL.String(), nil)
 						return r, nil
 					},
 					MockDo: func(req *http.Request, _ interface{}) error {
@@ -376,7 +376,7 @@ func TestListTemplates(t *testing.T) {
 						if prefix != templatesBasePath {
 							t.Errorf("unexpected prefix: %s", prefix)
 						}
-						r, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, testURL.String(), nil)
+						r, _ := http.NewRequestWithContext(ctx, http.MethodGet, testURL.String(), nil)
 						return r, nil
 					},
 					MockDo: func(req *http.Request, _ interface{}) error {
@@ -400,7 +400,7 @@ func TestListTemplates(t *testing.T) {
 						if prefix != templatesBasePath {
 							t.Errorf("unexpected prefix: %s", prefix)
 						}
-						r, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, testURL.String(), nil)
+						r, _ := http.NewRequestWithContext(ctx, http.MethodGet, testURL.String(), nil)
 						return r, nil
 					},
 					MockDo: func(req *http.Request, _ interface{}) error {

--- a/service/configurations/types.go
+++ b/service/configurations/types.go
@@ -59,3 +59,17 @@ type ConfigurationCreateParameters struct {
 	Repo       string   `json:"repo"`       // Name of the repo. Usually the same as the configuration name
 	TemplateID string   `json:"templateId"` // Name of the template we clone. There is no API for this today.
 }
+
+// ConfigurationTemplateReponse is a single configuration template
+// The ID of the template is the TemplateId for the ConfigurationCreateParameters
+type ConfigurationTemplateReponse struct {
+	ID       string `json:"id"`
+	ImageURI string `json:"imageUri"`
+	Name     string `json:"name"`
+	Repo     string `json:"repo"`
+}
+
+// ConfigurationTemplateListResponse is a list of configuration templates
+type ConfigurationTemplateListResponse struct {
+	Templates []ConfigurationTemplateReponse `json:"templates"`
+}


### PR DESCRIPTION
### Description
Add new configuration template API. It only supports one method: LIST

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
Unit test & tested with local copy of the `up` CLI.