### PR TITLE
Token owner ID should be able to accept both uint and UUID

### DIFF
--- a/service/tokens/types.go
+++ b/service/tokens/types.go
@@ -103,7 +103,7 @@ type TokenOwner struct {
 // TokenOwnerData describes a token owner.
 type TokenOwnerData struct {
 	Type TokenOwnerType `json:"type"`
-	ID   uuid.UUID      `json:"id"`
+	ID   string         `json:"id"`
 }
 
 // TokenAttributes represents attributes of a token.


### PR DESCRIPTION
### Description of your changes

In the upbound-api, owner of the token could be either a user or a robot. However, since the type of the ID is UUID in this type, we are not able to create a user token. Making it `string` allows for both types of owners to be used.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Not tested manually but local tests pass.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
