### PR TITLE
client: set status on errors so that IsNotFound works for them

### DIFF
--- a/client.go
+++ b/client.go
@@ -149,7 +149,7 @@ func (h *DefaultErrorHandler) Handle(res *http.Response) error {
 	// if we can read the body, try to unmarshal it into an error
 	// and if that fails, use the body as the details
 	if err == nil {
-		if err := json.Unmarshal(b, &rErr); err == nil {
+		if err := json.Unmarshal(b, &rErr); err == nil && rErr.Status != 0 {
 			return &rErr
 		}
 


### PR DESCRIPTION
### Description of your changes

Otherwise, we get `0` for all errors because server does not return an error with `status` field.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Manually.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
