### PR TITLE
Get all configurations instead of just the first ten.

### DIFF
--- a/service/configurations/client_test.go
+++ b/service/configurations/client_test.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -69,7 +70,7 @@ func TestList(t *testing.T) {
 						if prefix != basePath {
 							t.Errorf("unexpected prefix: %s", method)
 						}
-						if urlPath != account {
+						if !strings.HasPrefix(urlPath, account) {
 							t.Errorf("unexpected path: %s", urlPath)
 						}
 						r, _ := http.NewRequestWithContext(ctx, http.MethodGet, testURL.String(), nil)
@@ -99,7 +100,7 @@ func TestList(t *testing.T) {
 						if prefix != basePath {
 							t.Errorf("unexpected prefix: %s", method)
 						}
-						if urlPath != account {
+						if !strings.HasPrefix(urlPath, account) {
 							t.Errorf("unexpected path: %s", urlPath)
 						}
 						r, _ := http.NewRequestWithContext(ctx, http.MethodGet, testURL.String(), nil)

--- a/service/configurations/types.go
+++ b/service/configurations/types.go
@@ -49,6 +49,9 @@ type ConfigurationResponse struct {
 // ConfigurationListResponse is a list of all configurations belonging to the account.
 type ConfigurationListResponse struct {
 	Configurations []ConfigurationResponse `json:"configurations"`
+	Count          int                     `json:"count"`
+	Page           int                     `json:"page"`
+	Size           int                     `json:"size"`
 }
 
 // ConfigurationCreateParameters are the parameters for creating a control plane.


### PR DESCRIPTION
### Description of your changes
Update List() for configurations. Previously, it only got one page of configuration (the first ten). Now it gets all configurations. 

Fixes https://github.com/upbound/up/issues/403

### How has this code been tested
Tested locally with the up CLI. 