### PR TITLE
Controlplanes: make Configruation optional

### DIFF
--- a/service/controlplanes/types.go
+++ b/service/controlplanes/types.go
@@ -41,7 +41,7 @@ type ControlPlane struct {
 	CreatedAt     *time.Time                `json:"createdAt,omitempty"`
 	UpdatedAt     *time.Time                `json:"updatedAt,omitempty"`
 	ExpiresAt     time.Time                 `json:"expiresAt"`
-	Configuration ControlPlaneConfiguration `json:"configuration"`
+	Configuration ControlPlaneConfiguration `json:"configuration,omitempty"`
 }
 
 // PermissionGroup describes control plane permissions for the authenticated


### PR DESCRIPTION
### Description of your changes

We are relaxing the requirement that a control plane must have a configuration.

Fixes #

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.
