### PR TITLE
Control planes: make configuration truly optional

### DIFF
--- a/service/controlplanes/types.go
+++ b/service/controlplanes/types.go
@@ -33,15 +33,15 @@ const (
 
 // ControlPlane describes a control plane.
 type ControlPlane struct {
-	ID            uuid.UUID                 `json:"id,omitempty"`
-	Name          string                    `json:"name,omitempty"`
-	Description   string                    `json:"description,omitempty"`
-	CreatorID     uint                      `json:"creatorId,omitempty"`
-	Reserved      bool                      `json:"reserved"`
-	CreatedAt     *time.Time                `json:"createdAt,omitempty"`
-	UpdatedAt     *time.Time                `json:"updatedAt,omitempty"`
-	ExpiresAt     time.Time                 `json:"expiresAt"`
-	Configuration ControlPlaneConfiguration `json:"configuration,omitempty"`
+	ID            uuid.UUID                  `json:"id,omitempty"`
+	Name          string                     `json:"name,omitempty"`
+	Description   string                     `json:"description,omitempty"`
+	CreatorID     uint                       `json:"creatorId,omitempty"`
+	Reserved      bool                       `json:"reserved"`
+	CreatedAt     *time.Time                 `json:"createdAt,omitempty"`
+	UpdatedAt     *time.Time                 `json:"updatedAt,omitempty"`
+	ExpiresAt     time.Time                  `json:"expiresAt"`
+	Configuration *ControlPlaneConfiguration `json:"configuration,omitempty"`
 }
 
 // PermissionGroup describes control plane permissions for the authenticated
@@ -78,9 +78,9 @@ type ControlPlaneListResponse struct {
 
 // ControlPlaneCreateParameters are the parameters for creating a control plane.
 type ControlPlaneCreateParameters struct {
-	ConfigurationID uuid.UUID `json:"configurationId"`
-	Name            string    `json:"name"`
-	Description     string    `json:"description"`
+	ConfigurationID *uuid.UUID `json:"configurationId,omitempty"`
+	Name            string     `json:"name"`
+	Description     string     `json:"description"`
 }
 
 // ConfigurationStatus represents the different states of a Configuration relative to a Managed Control Plane.


### PR DESCRIPTION
### Description of your changes

This fully makes configurations optional by omitting configurations from the JSON.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Tested using a fork of the UP CLI:
```
minerva:~/src/up $ up ctp list -a upbound
NAME               ID                                     STATUS   CONFIGURATION            CONFIGURATION STATUS
tt-test-020        10731768-f73f-4613-abf0-53fd78935ca3   ready    configuration-rds-prod   ready
bh-nono            74a3a68c-b98b-422b-af9f-889eb5c58f03   ready    n/a                      n/a

```