### PR TITLE
query/v1alpha1: fix deepcopy panic for non-objects in JSON

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,10 +70,11 @@ jobs:
       # this action because it leaves 'annotations' (i.e. it comments on PRs to
       # point out linter violations).
       - name: Lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v4
         with:
           version: ${{ env.GOLANGCI_VERSION }}
-          skip-go-installation: true
+          skip-pkg-cache: true
+          skip-build-cache: true
 
   check-diff:
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           submodules: true
 
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -87,7 +87,7 @@ jobs:
           submodules: true
 
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -130,7 +130,7 @@ jobs:
         run: git fetch --prune --unshallow
 
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -101,7 +101,7 @@ linters:
     - govet
     - gocyclo
     - gocritic
-    - interfacer
+    # - interfacer # panic in spaces/v1alpha1
     - goconst
     - goimports
     - gofmt  # We enable this as well as goimports for its simplify mode.

--- a/apis/query/v1alpha1/json.go
+++ b/apis/query/v1alpha1/json.go
@@ -52,7 +52,7 @@ func (j *JSON) DeepCopy() *JSON {
 	if j == nil {
 		return nil
 	}
-	return &JSON{Object: runtime.DeepCopyJSONValue(j.Object).(map[string]interface{})}
+	return &JSON{Object: runtime.DeepCopyJSONValue(j.Object)}
 }
 
 // DeepCopyInto copies the receiver, writing into out.
@@ -64,7 +64,7 @@ func (j *JSON) DeepCopyInto(target *JSON) {
 		target.Object = nil // shouldn't happen
 		return
 	}
-	target.Object = runtime.DeepCopyJSONValue(j.Object).(map[string]interface{})
+	target.Object = runtime.DeepCopyJSONValue(j.Object)
 }
 
 // MarshalJSON implements json.Marshaler.

--- a/apis/spaces/v1alpha1/backup_types.go
+++ b/apis/spaces/v1alpha1/backup_types.go
@@ -17,10 +17,11 @@ package v1alpha1
 import (
 	"reflect"
 
-	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 )
 
 // +kubebuilder:object:root=true
@@ -194,6 +195,7 @@ type BackupStatus struct {
 	Details BackupStatusDetails `json:"details,omitempty"`
 }
 
+// BackupStatusDetails contains additional information about a backup.
 type BackupStatusDetails struct {
 	// UploadedFileName is the name of the uploaded file.
 	UploadedFileName string `json:"uploadedFileName,omitempty"`
@@ -207,6 +209,7 @@ type BackupStatusDetails struct {
 	ControlPlane *PreciseLocalObjectReference `json:"controlPlane,omitempty"`
 }
 
+// PreciseLocalObjectReference references by name and uid.
 type PreciseLocalObjectReference struct {
 	// Name is the name of the referenced object.
 	// +optional


### PR DESCRIPTION
JSON can have primitive types at the root. They panic'ed on deepcopy.