### PR TITLE
fix: gate rules using gated fields

### DIFF
--- a/apis/spaces/v1beta1/controlplane_types.go
+++ b/apis/spaces/v1beta1/controlplane_types.go
@@ -286,8 +286,8 @@ type SecretReference struct {
 }
 
 // A ControlPlaneSpec represents the desired state of the ControlPlane.
-// +kubebuilder:validation:XValidation:rule="!has(oldSelf.restore) || has(self.restore)",message="restore source can not be unset"
-// +kubebuilder:validation:XValidation:rule="has(oldSelf.restore) || !has(self.restore)",message="restore source can not be set after creation"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.restore) || has(self.restore)",message="[[GATE:EnableSharedBackup]] restore source can not be unset"
+// +kubebuilder:validation:XValidation:rule="has(oldSelf.restore) || !has(self.restore)",message="[[GATE:EnableSharedBackup]] restore source can not be set after creation"
 type ControlPlaneSpec struct {
 	// [[GATE:EnableGitSource]] THIS IS AN ALPHA FIELD. Do not use it in production.
 	// Source points to a Git repository containing a ControlPlaneSource


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes issue due to CEL rules using gated values when the gate is set to false:
```
{"level":"info","ts":"2024-04-03T11:12:20Z","logger":"mxe-apis","msg":"failed to apply crd controlplanes.spaces.upbound.io","error":"cannot create object: CustomResourceDefinition.apiextensions.k8s.io \"controlplanes.spaces.upbound.io\" is invalid: [spec.validation.openAPIV3Schema.properties[spec].x-kubernetes-validations[0].rule: Invalid value: apiextensions.ValidationRule{Rule:\"!has(oldSelf.restore) || has(self.restore)\", Message:\"restore source can not be unset\", MessageExpression:\"\"}: compilation failed: ERROR: <input>:1:5: undefined field 'restore'\n | !has(oldSelf.restore) || has(self.restore)\n | ....^\nERROR: <input>:1:29: undefined field 'restore'\n | !has(oldSelf.restore) || has(self.restore)\n | ............................^, spec.validation.openAPIV3Schema.properties[spec].x-kubernetes-validations[1].rule: Invalid value: apiextensions.ValidationRule{Rule:\"has(oldSelf.restore) || !has(self.restore)\", Message:\"restore source can not be set after creation\", MessageExpression:\"\"}: compilation failed: ERROR: <input>:1:4: undefined field 'restore'\n | has(oldSelf.restore) || !has(self.restore)\n | ...^\nERROR: <input>:1:29: undefined field 'restore'\n | has(oldSelf.restore) || !has(self.restore)\n | ............................^]"}
mxe-apis: error: failed to apply crd controlplanes.spaces.upbound.io: cannot create object: CustomResourceDefinition.apiextensions.k8s.io "controlplanes.spaces.upbound.io" is invalid: [spec.validation.openAPIV3Schema.properties[spec].x-kubernetes-validations[0].rule: Invalid value: apiextensions.ValidationRule{Rule:"!has(oldSelf.restore) || has(self.restore)", Message:"restore source can not be unset", MessageExpression:""}: compilation failed: ERROR: <input>:1:5: undefined field 'restore'
                  | !has(oldSelf.restore) || has(self.restore)
                  | ....^
                 ERROR: <input>:1:29: undefined field 'restore'
                  | !has(oldSelf.restore) || has(self.restore)
                  | ............................^, spec.validation.openAPIV3Schema.properties[spec].x-kubernetes-validations[1].rule: Invalid value: apiextensions.ValidationRule{Rule:"has(oldSelf.restore) || !has(self.restore)", Message:"restore source can not be set after creation", MessageExpression:""}: compilation failed: ERROR: <input>:1:4: undefined field 'restore'
                  | has(oldSelf.restore) || !has(self.restore)
                  | ...^
                 ERROR: <input>:1:29: undefined field 'restore'
                  | has(oldSelf.restore) || !has(self.restore)
                  | ............................^]
```

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR, as appropriate.~

### How has this code been tested

Deployed.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
