### PR TITLE
Remove reference to Velero from SharedBackupConfig

### DIFF
--- a/apis/spaces/v1alpha1/sharedbackupconfig_types.go
+++ b/apis/spaces/v1alpha1/sharedbackupconfig_types.go
@@ -51,7 +51,7 @@ type SharedBackupConfigList struct {
 }
 
 // A SharedBackupConfigSpec represents the configuration to backup or restore
-// ControlPlanes using Velero.
+// ControlPlanes.
 type SharedBackupConfigSpec struct {
 	// ObjectStorage specifies the object storage configuration for the given provider.
 	// +kubebuilder:validation:Required


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

Just what it says on the label, removes a bad reference.

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [X] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

N/A