### PR TITLE
Add deprecation notices to ControlPlane ConnectionDetail fields

### DIFF
--- a/apis/spaces/v1beta1/controlplane_types.go
+++ b/apis/spaces/v1beta1/controlplane_types.go
@@ -313,7 +313,7 @@ type ControlPlaneSpec struct {
 	// each other.
 	//
 	// If omitted, it is defaulted to the namespace of the ControlPlane.
-	//
+	// Deprecated: Use Hub or Upbound identities instead.
 	// +optional
 	WriteConnectionSecretToReference *SecretReference `json:"writeConnectionSecretToRef,omitempty"`
 	// PublishConnectionDetailsTo specifies the connection secret config which
@@ -322,6 +322,7 @@ type ControlPlaneSpec struct {
 	// Connection details frequently include the endpoint, username,
 	// and password required to connect to the managed resource.
 	//
+	// Deprecated: Use Hub or Upbound identities instead.
 	// +optional
 	PublishConnectionDetailsTo *xpv1.PublishConnectionDetailsTo `json:"publishConnectionDetailsTo,omitempty"`
 	// THIS IS AN ALPHA FIELD. Do not use it in production. It is not honored


### PR DESCRIPTION
### Description of your changes
Writing connectionDetails for a ControlPlane is being deprecated in Spaces 1.3 and will be removed in 1.4. This changeset adds a deprecation notice to the current API.

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
