### PR TITLE
Remove Last Schedule print column from SharedBackupSchedule

### DIFF
--- a/apis/spaces/v1alpha1/sharedbackupschedule_types.go
+++ b/apis/spaces/v1alpha1/sharedbackupschedule_types.go
@@ -30,7 +30,6 @@ const SharedBackupScheduleLabelKey = "spaces.upbound.io/sharedbackupschedule"
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Schedule",type="string",JSONPath=".spec.schedule"
 // +kubebuilder:printcolumn:name="Suspended",type="boolean",JSONPath=".spec.suspend"
-// +kubebuilder:printcolumn:name="Last schedule",type="date",JSONPath=".status.lastBackupTime"
 // +kubebuilder:printcolumn:name="Provisioned",type="string",JSONPath=`.metadata.annotations.sharedbackupschedule\.internal\.spaces\.upbound\.io/provisioned-total`
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:scope=Namespaced,categories=spaces


### PR DESCRIPTION
### Description of your changes

This PR removes the Last Schedule print column from the SharedBackupSchedule, since the `.status.lastBackupTime` field doesn't exist in the API.

Part of https://github.com/upbound/spaces/issues/980

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
