### PR TITLE
Add 1.4.0 block for working against pre-releases in cloud

### DIFF
--- a/service/spaces/crossplane/supported_versions.yaml
+++ b/service/spaces/crossplane/supported_versions.yaml
@@ -1,5 +1,21 @@
 apiVersion: v1
 supportedVersions:
+  - spacesVersion: 1.4.0
+    crossplaneVersions:
+    - version: 1.15.2-up.1
+    - version: 1.15.1-up.1
+    - version: 1.15.0-up.1
+    - version: 1.14.8-up.1
+    - version: 1.14.7-up.1
+    - version: 1.14.6-up.1
+    - version: 1.14.5-up.1
+    - version: 1.14.4-up.1
+    - version: 1.14.3-up.1
+    - version: 1.14.2-up.1
+    - version: 1.14.1-up.1
+    - version: 1.13.2-up.3
+    - version: 1.13.2-up.2
+    - version: 1.13.2-up.1
   - spacesVersion: 1.3.0
     crossplaneVersions:
     - version: 1.15.2-up.1


### PR DESCRIPTION
### Description of your changes
Adds 1.4.0 block for working against pre-releases that are starting to roll out in cloud.

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
N/A metadata file.
