### PR TITLE
Add CEL rule for rejecting empty version with upgrade policy "None"

### DIFF
--- a/apis/spaces/v1beta1/controlplane_types.go
+++ b/apis/spaces/v1beta1/controlplane_types.go
@@ -297,6 +297,7 @@ type SecretReference struct {
 // A ControlPlaneSpec represents the desired state of the ControlPlane.
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.restore) || has(self.restore)",message="[[GATE:EnableSharedBackup]] restore source can not be unset"
 // +kubebuilder:validation:XValidation:rule="has(oldSelf.restore) || !has(self.restore)",message="[[GATE:EnableSharedBackup]] restore source can not be set after creation"
+// +kubebuilder:validation:XValidation:rule="!has(self.crossplane.autoUpgrade) || self.crossplane.autoUpgrade.channel != \"None\" || self.crossplane.version != \"\"",message="\"version\" cannot be empty when upgrade channel is \"None\""
 type ControlPlaneSpec struct {
 	// [[GATE:EnableGitSource]] THIS IS AN ALPHA FIELD. Do not use it in production.
 	// Source points to a Git repository containing a ControlPlaneSource


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

This change adds a new CEL rule to ctp objects which prevents creating ctp resources with no version when the upgrade policy is "Non".

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes #

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested
I've consumed the change in spaces repo and applied following manifests.

Rejected:
- Upgrade policy is None and no version:
```yaml
apiVersion: spaces.upbound.io/v1beta1
kind: ControlPlane
metadata:
  labels:
    # example label, to be matched in SharedSecretStore/SharedExternalSecret examples
    org: foo
  name: none-ctp
spec:
  crossplane:
    autoUpgrade:
      channel: None
  writeConnectionSecretToRef:
    name: kubeconfig-ctp

```
- Upgrade policy is None and version is "":
```yaml
apiVersion: spaces.upbound.io/v1beta1
kind: ControlPlane
metadata:
  labels:
    # example label, to be matched in SharedSecretStore/SharedExternalSecret examples
    org: foo
  name: ctp
spec:
  crossplane:
    autoUpgrade:
      channel: None
    version: ""
  writeConnectionSecretToRef:
    name: kubeconfig-ctp
```

Accepted:
- No crossplane subfield defined:
```yaml
apiVersion: spaces.upbound.io/v1beta1
kind: ControlPlane
metadata:
  labels:
    # example label, to be matched in SharedSecretStore/SharedExternalSecret examples
    org: foo
  name: ctp-2
spec:
  writeConnectionSecretToRef:
    name: kubeconfig-ctp-2
```
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
