### PR TITLE
Add new `apiURL` field to space status

### DIFF
--- a/apis/upbound/v1alpha1/space_types.go
+++ b/apis/upbound/v1alpha1/space_types.go
@@ -106,6 +106,11 @@ type SpaceStatus struct {
 	// +optional
 	// The FQDN endpoint for the Space Cluster used for Ingress
 	FQDN string `json:"fqdn,omitempty"`
+	// +optional
+	// The URL for contacting the Space API. This value should be used to get
+	// the ingress host and CA data, then the ingress should be used for all
+	// future communication.
+	APIURL string `json:"apiURL,omitempty"`
 	// The statuses and timestamps surrounding the connection to the space
 	ConnectionDetails ConnectionDetails `json:"connection,omitempty"`
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

Part of https://github.com/upbound/team-orchestration/issues/99

Add the `apiURL` field to space status, which will pass the connect path for the space - used to get the ingress. The `FQDN` can be deprecated and removed later, once `up` transitions to querying for the host ingress and CA data from the space directly.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
