### PR TITLE
feat(robot): add options for robot teammembership + typed team responses

### DIFF
--- a/service/robots/client.go
+++ b/service/robots/client.go
@@ -26,8 +26,9 @@ import (
 )
 
 const (
-	basePath   = "v2/robots"
-	tokensPath = "tokens"
+	basePath          = "v2/robots"
+	tokensPath        = "tokens"
+	teamsRelationPath = "relationships/teams"
 )
 
 // Client is an robots client.
@@ -91,6 +92,28 @@ func (c *Client) ListTokens(ctx context.Context, id uuid.UUID) (*tokens.TokensRe
 // Delete an robot on Upbound.
 func (c *Client) Delete(ctx context.Context, id uuid.UUID) error { // nolint:interfacer
 	req, err := c.Client.NewRequest(ctx, http.MethodDelete, basePath, id.String(), nil)
+	if err != nil {
+		return err
+	}
+	return c.Client.Do(req, nil)
+}
+
+// CreateTeamMembership create a robot team membership on Upbound.
+func (c *Client) CreateTeamMembership(ctx context.Context, id uuid.UUID, params *RobotTeamMembershipResourceIdentifier) error {
+	req, err := c.Client.NewRequest(ctx, http.MethodPost, basePath, path.Join(id.String(), teamsRelationPath), &RobotTeamMembershipRelationshipList{
+		Data: []RobotTeamMembershipResourceIdentifier{*params},
+	})
+	if err != nil {
+		return err
+	}
+	return c.Client.Do(req, nil)
+}
+
+// DeleteTeamMembership delete a robot team membership on Upbound.
+func (c *Client) DeleteTeamMembership(ctx context.Context, id uuid.UUID, params *RobotTeamMembershipResourceIdentifier) error {
+	req, err := c.Client.NewRequest(ctx, http.MethodDelete, basePath, path.Join(id.String(), teamsRelationPath), &RobotTeamMembershipRelationshipList{
+		Data: []RobotTeamMembershipResourceIdentifier{*params},
+	})
 	if err != nil {
 		return err
 	}

--- a/service/robots/types.go
+++ b/service/robots/types.go
@@ -23,7 +23,8 @@ type RobotOwnerType string
 
 // Robots can be owned by an organization.
 const (
-	RobotOwnerOrganization RobotOwnerType = "organization"
+	RobotOwnerOrganization      RobotOwnerType = "organization"
+	RobotTeamMembershipTypeTeam string         = "teams"
 )
 
 // bodyType is the type of request in the data body.
@@ -86,4 +87,15 @@ type RobotResponse struct {
 type RobotAttributes struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`
+}
+
+// RobotTeamMembershipResourceIdentifier are the attributes of a robot team membership.
+type RobotTeamMembershipResourceIdentifier struct {
+	Type string `json:"type"`
+	ID   string `json:"id"`
+}
+
+// RobotTeamMembershipRelationshipList represents RobotTeamMembershipResourceIdentifier relationships.
+type RobotTeamMembershipRelationshipList struct {
+	Data []RobotTeamMembershipResourceIdentifier `json:"data"`
 }

--- a/service/teams/types.go
+++ b/service/teams/types.go
@@ -15,7 +15,9 @@
 package teams
 
 import (
-	"github.com/upbound/up-sdk-go/service/common"
+	"time"
+
+	"github.com/google/uuid"
 )
 
 // TeamCreateParameters are the parameters for creating a team.
@@ -24,14 +26,14 @@ type TeamCreateParameters struct {
 	OrganizationID uint   `json:"organizationId"`
 }
 
-// TeamsResponse is the response returned from team operations.
-type TeamsResponse struct { //nolint:golint
-	DataSet []common.DataSet `json:"data"`
-}
-
 // TeamResponse is the response returned from team operations.
 type TeamResponse struct {
-	common.DataSet `json:"data"`
+	ID             uuid.UUID  `json:"id"`
+	OrganizationID uint       `json:"organizationId"`
+	AccountID      uint       `json:"accountId"`
+	Name           string     `json:"name"`
+	CreatorID      uint       `json:"creatorId"`
+	CreatedAt      *time.Time `json:"createdAt,omitempty"`
 }
 
 // TeamAttributes are the attributes of a team.


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes
- add create / delete for robot team memberships
- typed team response instead of generic DataSet to ex. extract names

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes #54

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested
via up-cli PR:

```
up robot membership create chris test123 -a upboundcare
upboundcare/chris/test123 team membership created
```

<img width="1303" alt="image" src="https://github.com/upbound/up-sdk-go/assets/21083497/ec5b5111-86b8-4dce-9e93-5acec521f304">


```
up robot membership get chris -a upboundcare    
TEAM MEMBERSHIP
test444
test123
```

```
up robot membership delete chris test123 -a upboundcare
Are you sure you want to delete this robot team membership? This cannot be undone [y/n]: y
Deleting robot team membership upboundcare/chris/test123.
upboundcare/chris/test123 deleted
```

```
up robot membership get chris -a upboundcare
TEAM MEMBERSHIP
test444
```

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
