### PR TITLE
feat(sdk): add repositorypermission

### DIFF
--- a/service/repositorypermission/client.go
+++ b/service/repositorypermission/client.go
@@ -1,0 +1,72 @@
+// Copyright 2024 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package repositorypermission
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+
+	"github.com/upbound/up-sdk-go"
+)
+
+const (
+	basePath = "v1/repoPermissions/%s/teams/%s"
+)
+
+// Client is a repositories permission client.
+type Client struct {
+	*up.Config
+}
+
+// NewClient build a repositories permission client from the passed config.
+func NewClient(cfg *up.Config) *Client {
+	return &Client{
+		cfg,
+	}
+}
+
+// Create assigns a specified permission to a team for a repository on Upbound.
+func (c *Client) Create(ctx context.Context, organization string, teamID uuid.UUID, params CreatePermission) error {
+	req, err := c.Client.NewRequest(ctx, http.MethodPut, fmt.Sprintf(basePath, organization, teamID), params.Repository, params.Permission)
+	if err != nil {
+		return err
+	}
+	return c.Client.Do(req, nil)
+}
+
+// Delete removes a specified permission from a team for a repository on Upbound.
+func (c *Client) Delete(ctx context.Context, organization string, teamID uuid.UUID, params PermissionIdentifier) error { // nolint:interfacer
+	req, err := c.Client.NewRequest(ctx, http.MethodDelete, fmt.Sprintf(basePath, organization, teamID), params.Repository, nil)
+	if err != nil {
+		return err
+	}
+	return c.Client.Do(req, nil)
+}
+
+// List retrieves all repository permissions assigned to a team on Upbound.
+func (c *Client) List(ctx context.Context, organization string, teamID uuid.UUID) (*ListPermissionsResponse, error) {
+	req, err := c.Client.NewRequest(ctx, http.MethodGet, fmt.Sprintf(basePath, organization, teamID), "", nil)
+	if err != nil {
+		return nil, err
+	}
+	r := &ListPermissionsResponse{}
+	if err := c.Client.Do(req, r); err != nil {
+		return nil, err
+	}
+	return r, nil
+}

--- a/service/repositorypermission/types.go
+++ b/service/repositorypermission/types.go
@@ -1,0 +1,68 @@
+// Copyright 2024 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package repositorypermission
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// PermissionType represents the type of permission for a repository.
+type PermissionType string
+
+// PermissionTypes
+const (
+	PermissionAdmin PermissionType = "admin"
+	PermissionRead  PermissionType = "read"
+	PermissionWrite PermissionType = "write"
+	PermissionView  PermissionType = "view"
+)
+
+// RepositoryPermission represents the permission to be set for a repository.
+type RepositoryPermission struct {
+	Permission PermissionType `json:"permission"`
+}
+
+// CreatePermission holds the parameters for creating a repository permission.
+type CreatePermission struct {
+	Permission RepositoryPermission `json:"permission"`
+	Repository string               `json:"repository"`
+}
+
+// PermissionIdentifier holds the parameters for a repository permission.
+type PermissionIdentifier struct {
+	Repository string `json:"repository"`
+}
+
+// Permission represents a repository permission entry.
+type Permission struct {
+	TeamID         uuid.UUID      `json:"teamId"`
+	RepositoryID   int            `json:"repositoryId"`
+	AccountID      int            `json:"accountId"`
+	Privilege      PermissionType `json:"privilege"`
+	CreatorID      int            `json:"creatorId"`
+	CreatedAt      time.Time      `json:"createdAt"`
+	UpdatedAt      *time.Time     `json:"updatedAt,omitempty"`
+	RepositoryName string         `json:"repositoryName"`
+}
+
+// ListPermissionsResponse represents the response from listing repository permissions.
+type ListPermissionsResponse struct {
+	Permissions []Permission `json:"permissions"`
+	Size        int          `json:"size"`
+	Page        int          `json:"page"`
+	Count       int          `json:"count"`
+}


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes
- add create, delete and list endpoint for repositorypermission

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes #52

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested
with corresponding up-cli implementation:

```
up repo permission list test123 -a upboundcare
TEAM      REPOSITORY   PERMISSION   CREATED                UPDATED
test123   repo         write        2024-06-23T18:56:58Z   n/a
```

```
up repo permission delete test123 repo -a upboundcare
Are you sure you want to delete this repository permission? This cannot be undone [y/n]: y
Deleting repository permission for team "test123" in repository "repo"
Repository permission for team "test123" in repository "repo" deleted
```

```
up repo permission create test123 repo write -a upboundcare
Permission write granted to team test123 for repository repo in account upboundcare
```


<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
