### PR TITLE
ControlPlanes: remove scheduled and add healthy condition

### DIFF
--- a/apis/spaces/v1beta1/conditions.go
+++ b/apis/spaces/v1beta1/conditions.go
@@ -13,24 +13,19 @@ import (
 )
 
 const (
+	// ConditionTypeHealthy indicates that the control plane is healthy.
+	ConditionTypeHealthy xpcommonv1.ConditionType = "Healthy"
+	// ReasonHealthy indicates that the control plane is healthy.
+	ReasonHealthy xpcommonv1.ConditionReason = "HealthyControlPlane"
+	// ReasonUnhealthy indicates that the control plane is unhealthy.
+	ReasonUnhealthy xpcommonv1.ConditionReason = "UnhealthyControlPlane"
+
 	// ConditionTypeSourceSynced indicates that the git source is in sync.
 	ConditionTypeSourceSynced xpcommonv1.ConditionType = "SourceSynced"
 	// ReasonSourceCompleted indicates that the git sync has been completed.
 	ReasonSourceCompleted xpcommonv1.ConditionReason = "Completed"
 	// ReasonSourceInProgress indicates that the git sync is still in progress.
 	ReasonSourceInProgress xpcommonv1.ConditionReason = "InProgress"
-
-	// ConditionTypeScheduled indicates that the control plane has been scheduled.
-	ConditionTypeScheduled xpcommonv1.ConditionType = "Scheduled"
-	// ReasonScheduled indicates that the control plane has been scheduled.
-	ReasonScheduled xpcommonv1.ConditionReason = "Scheduled"
-	// ReasonSchedulingError indicates that the control plane scheduling had an error.
-	ReasonSchedulingError xpcommonv1.ConditionReason = "SchedulingError"
-	// ReasonSchedulingFailed indicates that the control plane scheduling did not succeed
-	// for non-error reasons, e.g. capacity.
-	ReasonSchedulingFailed xpcommonv1.ConditionReason = "ScheduleFailed"
-	// ReasonDeploymentFailed indicates that the control plane deployment did not succeed.
-	ReasonDeploymentFailed xpcommonv1.ConditionReason = "DeploymentFailed"
 
 	// ConditionTypeSupported indicates that the control plane is running a
 	// supported version of Crossplane.
@@ -52,6 +47,25 @@ const (
 	// ReasonRestorePending indicates that the control plane restore is pending.
 	ReasonRestorePending xpcommonv1.ConditionReason = "RestorePending"
 )
+
+func Healthy() xpcommonv1.Condition {
+	return xpcommonv1.Condition{
+		Type:               ConditionTypeHealthy,
+		Status:             corev1.ConditionTrue,
+		LastTransitionTime: metav1.Now(),
+		Reason:             ReasonHealthy,
+	}
+}
+
+func Unhealthy(err error) xpcommonv1.Condition {
+	return xpcommonv1.Condition{
+		Type:               ConditionTypeHealthy,
+		Status:             corev1.ConditionFalse,
+		LastTransitionTime: metav1.Now(),
+		Reason:             ReasonUnhealthy,
+		Message:            err.Error(),
+	}
+}
 
 // SourceSynced returns a condition that indicates the control plane is in sync
 // with the source.
@@ -85,53 +99,6 @@ func SourceError(err error) xpcommonv1.Condition {
 		Status:             corev1.ConditionFalse,
 		LastTransitionTime: metav1.Now(),
 		Reason:             ReasonSourceInProgress,
-		Message:            err.Error(),
-	}
-}
-
-// Scheduled returns a condition that indicates that scheduling of the
-// control plane has succeeded.
-func Scheduled() xpcommonv1.Condition {
-	return xpcommonv1.Condition{
-		Type:               ConditionTypeScheduled,
-		Status:             corev1.ConditionTrue,
-		LastTransitionTime: metav1.Now(),
-		Reason:             ReasonScheduled,
-	}
-}
-
-// SchedulingError returns a condition that indicates that scheduling of the
-// control plane had an error.
-func SchedulingError(err error) xpcommonv1.Condition {
-	return xpcommonv1.Condition{
-		Type:               ConditionTypeScheduled,
-		Status:             corev1.ConditionFalse,
-		LastTransitionTime: metav1.Now(),
-		Reason:             ReasonSchedulingError,
-		Message:            err.Error(),
-	}
-}
-
-// SchedulingFailed returns a condition that indicates that scheduling of the
-// control plane did not succeed.
-func SchedulingFailed(reason string) xpcommonv1.Condition {
-	return xpcommonv1.Condition{
-		Type:               ConditionTypeScheduled,
-		Status:             corev1.ConditionFalse,
-		LastTransitionTime: metav1.Now(),
-		Reason:             ReasonSchedulingFailed,
-		Message:            reason,
-	}
-}
-
-// DeploymentFailed returns a condition that indicates that deployment of the
-// control plane to a host cluster did not succeed.
-func DeploymentFailed(err error) xpcommonv1.Condition {
-	return xpcommonv1.Condition{
-		Type:               ConditionTypeScheduled,
-		Status:             corev1.ConditionFalse,
-		LastTransitionTime: metav1.Now(),
-		Reason:             ReasonDeploymentFailed,
 		Message:            err.Error(),
 	}
 }

--- a/apis/spaces/v1beta1/conditions.go
+++ b/apis/spaces/v1beta1/conditions.go
@@ -20,6 +20,13 @@ const (
 	// ReasonUnhealthy indicates that the control plane is unhealthy.
 	ReasonUnhealthy xpcommonv1.ConditionReason = "UnhealthyControlPlane"
 
+	// ConditionTypeControlPlaneProvisioned indicates that the control plane is provisioned.
+	ConditionTypeControlPlaneProvisioned xpcommonv1.ConditionType = "ControlPlaneProvisioned"
+	// ReasonProvisioned indicates that the control plane is provisioned.
+	ReasonProvisioned xpcommonv1.ConditionReason = "Provisioned"
+	// ReasonProvisioningError indicates that the control plane provisioning has failed.
+	ReasonProvisioningError xpcommonv1.ConditionReason = "ProvisioningError"
+
 	// ConditionTypeSourceSynced indicates that the git source is in sync.
 	ConditionTypeSourceSynced xpcommonv1.ConditionType = "SourceSynced"
 	// ReasonSourceCompleted indicates that the git sync has been completed.
@@ -48,6 +55,7 @@ const (
 	ReasonRestorePending xpcommonv1.ConditionReason = "RestorePending"
 )
 
+// Healthy returns a condition that indicates the control plane is healthy.
 func Healthy() xpcommonv1.Condition {
 	return xpcommonv1.Condition{
 		Type:               ConditionTypeHealthy,
@@ -57,12 +65,46 @@ func Healthy() xpcommonv1.Condition {
 	}
 }
 
-func Unhealthy(err error) xpcommonv1.Condition {
+// Unhealthy returns a condition that indicates the control plane is unhealthy.
+func Unhealthy() xpcommonv1.Condition {
 	return xpcommonv1.Condition{
 		Type:               ConditionTypeHealthy,
 		Status:             corev1.ConditionFalse,
 		LastTransitionTime: metav1.Now(),
 		Reason:             ReasonUnhealthy,
+	}
+}
+
+// ControlPlaneProvisioned returns a condition that indicates the control plane
+// has been provisioned.
+func ControlPlaneProvisioned() xpcommonv1.Condition {
+	return xpcommonv1.Condition{
+		Type:               ConditionTypeControlPlaneProvisioned,
+		Status:             corev1.ConditionTrue,
+		LastTransitionTime: metav1.Now(),
+		Reason:             ReasonProvisioned,
+	}
+}
+
+// ControlPlaneProvisionInProgress returns a condition that indicates the control
+// plane is still being provisioned.
+func ControlPlaneProvisionInProgress() xpcommonv1.Condition {
+	return xpcommonv1.Condition{
+		Type:               ConditionTypeControlPlaneProvisioned,
+		Status:             corev1.ConditionFalse,
+		LastTransitionTime: metav1.Now(),
+		Reason:             ReasonProvisioned,
+	}
+}
+
+// ControlPlaneProvisioningError returns a condition that indicates the control
+// plane provisioning has failed.
+func ControlPlaneProvisioningError(err error) xpcommonv1.Condition {
+	return xpcommonv1.Condition{
+		Type:               ConditionTypeControlPlaneProvisioned,
+		Status:             corev1.ConditionFalse,
+		LastTransitionTime: metav1.Now(),
+		Reason:             ReasonProvisioningError,
 		Message:            err.Error(),
 	}
 }

--- a/apis/spaces/v1beta1/controlplane_types.go
+++ b/apis/spaces/v1beta1/controlplane_types.go
@@ -366,6 +366,7 @@ type Restore struct {
 type ControlPlaneStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
 
+	Message        string `json:"message,omitempty"`
 	ControlPlaneID string `json:"controlPlaneID,omitempty"`
 	HostClusterID  string `json:"hostClusterID,omitempty"`
 
@@ -377,9 +378,9 @@ type ControlPlaneStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:storageversion
 // +kubebuilder:printcolumn:name="Crossplane",type="string",JSONPath=".spec.crossplane.version"
-// +kubebuilder:printcolumn:name="Synced",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
-// +kubebuilder:printcolumn:name="Message",type="string",JSONPath=`.metadata.annotations['internal\.spaces\.upbound\.io/message']`
+// +kubebuilder:printcolumn:name="Healthy",type="string",JSONPath=".status.conditions[?(@.type=='Healthy')].status"
+// +kubebuilder:printcolumn:name="Message",type="string",JSONPath=`.status.message`
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Namespaced,categories=spaces,shortName=ctp;ctps

--- a/apis/spaces/v1beta1/controlplane_types.go
+++ b/apis/spaces/v1beta1/controlplane_types.go
@@ -365,7 +365,8 @@ type Restore struct {
 // A ControlPlaneStatus represents the observed state of a ControlPlane.
 type ControlPlaneStatus struct {
 	xpv1.ResourceStatus `json:",inline"`
-
+	// Message is a human-readable message indicating details about why the
+	// ControlPlane is in this condition.
 	Message        string `json:"message,omitempty"`
 	ControlPlaneID string `json:"controlPlaneID,omitempty"`
 	HostClusterID  string `json:"hostClusterID,omitempty"`


### PR DESCRIPTION
### Description of your changes

As part of the Spaces control plane provisioning improvements, this PR makes the following changes:

- Removes  `Scheduled` condition type
- Adds `Healthy` condition type
- Adds `ControlPlaneProvisioned` condition type
- Adds `status.message` field to communicate a user friendly message about the provisioning (replacing the existing `internal.spaces.upbound.io/message` annotation
- Updates print columns accordingly

I have:

- [ ] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Together with the relevant Spaces PR:

```
❯ kubectl get ctp -w
NAME   CROSSPLANE    READY   HEALTHY   MESSAGE   AGE
ctp    1.15.3-up.1                               3s
ctp    1.15.3-up.1   False   False     Waiting for control plane API   6s
ctp    1.15.3-up.1   False   False     Waiting for Crossplane pods to be ready   60s
ctp    1.15.3-up.1   True    False     Waiting for Crossplane pods to be ready   65s
ctp    1.15.3-up.1   True    False     Control plane is Ready but not Healthy    69s
ctp    1.15.3-up.1   True    False     Control plane is Ready but not Healthy    74s
ctp    1.15.3-up.1   True    False     Control plane is Ready but not Healthy    80s
ctp    1.15.3-up.1   True    True                                                85s
```
