### PR TITLE
Remove hostcluster id from control plane status

### DIFF
--- a/apis/spaces/v1beta1/controlplane_types.go
+++ b/apis/spaces/v1beta1/controlplane_types.go
@@ -251,7 +251,6 @@ type ControlPlaneStatus struct {
 	// ControlPlane is in this condition.
 	Message        string `json:"message,omitempty"`
 	ControlPlaneID string `json:"controlPlaneID,omitempty"`
-	HostClusterID  string `json:"hostClusterID,omitempty"`
 }
 
 // +kubebuilder:object:root=true


### PR DESCRIPTION
### Description of your changes

Remove no longer used hostcluster id from status.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR, as appropriate.~

### How has this code been tested

With the consuming PR on the Spaces side.
