### PR TITLE
ControlPlane: Drop healthy column

### DIFF
--- a/apis/spaces/v1beta1/controlplane_types.go
+++ b/apis/spaces/v1beta1/controlplane_types.go
@@ -257,7 +257,6 @@ type ControlPlaneStatus struct {
 // +kubebuilder:storageversion
 // +kubebuilder:printcolumn:name="Crossplane",type="string",JSONPath=".spec.crossplane.version"
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
-// +kubebuilder:printcolumn:name="Healthy",type="string",JSONPath=".status.conditions[?(@.type=='Healthy')].status"
 // +kubebuilder:printcolumn:name="Message",type="string",JSONPath=`.status.message`
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:subresource:status


### PR DESCRIPTION
### Description of your changes

This PR drops healthy column from the ControlPlane print columns. We will enhance Message with a state to communicate health.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

```bash
NAME   CROSSPLANE    READY   MESSAGE   AGE
test   1.15.5-up.2            Creating   3s
test   1.15.5-up.2   False   Creating   11s
test   1.15.5-up.2   False   Creating: Waiting for control plane API   11s
test   1.15.5-up.2   False   Creating: Waiting for control plane API: Gateway deployment not...   50s
test   1.15.5-up.2   True    Creating: There are unready deployments: external-secrets-opera...   64s
test   1.15.5-up.2   True    Available                                                            74s

test   1.15.5-up.2   True    Degraded: There are unready deployments: kube-state-metrics          7m
test   1.15.5-up.2   True    Available                                                            7m10s
test   1.15.5-up.2   True    Deleting: Deletion in progress                                       9m25s
```
