### PR TITLE
repositories: Add support for setting visibility

### DIFF
--- a/service/repositories/types.go
+++ b/service/repositories/types.go
@@ -86,3 +86,9 @@ type RepositoryListResponse struct {
 	Page         int          `json:"page"`
 	Count        int          `json:"count"`
 }
+
+// RepositoryCreateOrUpdateRequest is the HTTP body for creating or updating a
+// repository.
+type RepositoryCreateOrUpdateRequest struct {
+	Public bool `json:"public"`
+}


### PR DESCRIPTION
### Description of your changes

It's now possible to create private repositories. Add an argument to `CreateOrUpdate` indicating whether a repository should be public and pass it to the API.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
~- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.~

### How has this code been tested

Updated unit tests, local integration into `up` CLI for testing against the real API.
