### PR TITLE
add CRD validation for XP version in ControlPlanes has no leading v

### DIFF
--- a/apis/spaces/v1beta1/controlplane_types.go
+++ b/apis/spaces/v1beta1/controlplane_types.go
@@ -141,6 +141,7 @@ type CrossplaneAutoUpgradeSpec struct {
 type CrossplaneSpec struct {
 	// Version is the version of Universal Crossplane to install.
 	// +optional
+	// +kubebuilder:validation:XValidation:rule=(self.matches('^[^v].*')),message=The version must not start with a leading 'v'
 	Version *string `json:"version,omitempty"`
 
 	// AutoUpgrades defines the auto upgrade configuration for Crossplane.


### PR DESCRIPTION
### Description of your changes

adds a CEL validation rule for `spec.crossplane.version` in `ControlPlane` API, that rejects Crossplane versions with leading `v` , e.g. up ctp create test-ctp-2 --crossplane-version="v1.17.3-up.1" --crossplane-channel="None"

https://github.com/upbound/spaces/issues/641#issuecomment-2135958977 mentions that, versions with leading `v` is accepted without errors when creating a `ControlPlane` object, though the created control plane becomes stuck at `Provisioning` state.

the Up CLI experience is already rejecting leading v. 
```sh
$ up ctp create test-ctp --crossplane-version="v1.17.3-up.1" --crossplane-channel="None"
up: error: controlplane (ctp) create: invalid Crossplane version specified: Invalid character(s) found in major number "v1"; do not prefix the version with a 'v'
```
With this PR, the validation will be also done at the admission time.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- ~[x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.~

### How has this code been tested
- consume this `up-sdk-go` PR in spaces by `go.mod` replacement
- make generate
- observe the `ControlPlane` CRD has now a validation rule for `spec.crossplane.version`
- `make tilt.up` to install spaces

#### Invalid Versions
- `kubectl apply` the following `ControlPlane` manifest
```yaml
apiVersion: spaces.upbound.io/v1beta1
kind: ControlPlane
metadata:
  name: test-ctp
  namespace: default
spec:
  class: default
  crossplane:
    autoUpgrade:
      channel: None
    state: Running
    version: v1.17.3-up.1
```
Observe the error
```
The ControlPlane "test-ctp" is invalid: spec.crossplane.version: Invalid value: "string": The version must not start with a leading 'v'
```
#### Valid versions - regression test
Observe that following `ControlPlane` manifests can be created successfully and provisioned
no version
```yaml
apiVersion: spaces.upbound.io/v1beta1
kind: ControlPlane
metadata:
  name: test-ctp-noversion
  namespace: default
spec:
  class: default
  crossplane:
    autoUpgrade:
      channel: Stable
    state: Running
```
valid version
```yaml
apiVersion: spaces.upbound.io/v1beta1
kind: ControlPlane
metadata:
  name: test-ctp-valid
  namespace: default
spec:
  class: default
  crossplane:
    autoUpgrade:
      channel: None
    state: Running
    version: v1.17.3-up.1
```