### PR TITLE
[backport release-1.8] resource-selector: fix case with multiple label selectors

### DIFF
--- a/apis/spaces/v1alpha1/resource_selector_test.go
+++ b/apis/spaces/v1alpha1/resource_selector_test.go
@@ -151,6 +151,34 @@ func TestResourceSelector(t *testing.T) {
 			},
 			matched: false,
 		},
+		"SomeObjectLabelsMatch": {
+			reason: "object is matched if some labels selector matches, not necessarily all",
+			obj: object{
+				labels: map[string]string{
+					"l1": "v1",
+				},
+			},
+			selector: ResourceSelector{
+				LabelSelectors: []metav1.LabelSelector{
+					{
+						MatchLabels: map[string]string{
+							"l1": "something",
+						},
+					},
+					{
+						MatchLabels: map[string]string{
+							"l1": "v1",
+						},
+					},
+					{
+						MatchLabels: map[string]string{
+							"l1": "elephant",
+						},
+					},
+				},
+			},
+			matched: true,
+		},
 		"ObjectLabelsOrNameNotMatched": {
 			reason: "object is not matched if neither its name nor labels matche the declared selector",
 			obj: object{


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

Backport of #135 

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes #

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- ~[ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.~

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
