### PR TITLE
[Backport release-1.9-fixed] resource-selector: fix case with multiple label selectors

### DIFF
--- a/apis/spaces/v1alpha1/resource_selector_test.go
+++ b/apis/spaces/v1alpha1/resource_selector_test.go
@@ -151,6 +151,34 @@ func TestResourceSelector(t *testing.T) {
 			},
 			matched: false,
 		},
+		"SomeObjectLabelsMatch": {
+			reason: "object is matched if some labels selector matches, not necessarily all",
+			obj: object{
+				labels: map[string]string{
+					"l1": "v1",
+				},
+			},
+			selector: ResourceSelector{
+				LabelSelectors: []metav1.LabelSelector{
+					{
+						MatchLabels: map[string]string{
+							"l1": "something",
+						},
+					},
+					{
+						MatchLabels: map[string]string{
+							"l1": "v1",
+						},
+					},
+					{
+						MatchLabels: map[string]string{
+							"l1": "elephant",
+						},
+					},
+				},
+			},
+			matched: true,
+		},
 		"ObjectLabelsOrNameNotMatched": {
 			reason: "object is not matched if neither its name nor labels matche the declared selector",
 			obj: object{


### PR DESCRIPTION
### Description of your changes

There were some commits missing in previous release-1.9 branch, so, created release-1.9-fixed from the correct commit (which Spaces release-1.9 depends on) and backporting this fix again.

Backports #135 

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR, as appropriate.~

### How has this code been tested

CI