### PR TITLE
Limit control plane name to 63 chars at max

### DIFF
--- a/apis/spaces/v1beta1/controlplane_types.go
+++ b/apis/spaces/v1beta1/controlplane_types.go
@@ -259,6 +259,7 @@ type ResourceUsage struct {
 // +kubebuilder:resource:scope=Namespaced,categories=spaces,shortName=ctp;ctps
 
 // ControlPlane defines a managed Crossplane instance.
+// +kubebuilder:validation:XValidation:rule="self.metadata.name.size() <= 63",message="control plane name cannot exceed 63 characters"
 type ControlPlane struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
### Description of your changes

Currently, we cannot provision control planes when their names are longer than 63 chars. The primary blocker for this is, we are adding a label on the host namespace with the value being control plane name. 

This PR defines a CEL rule to ensure it is not possible to create control planes with names longer than 63 chars.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR, as appropriate.~

### How has this code been tested

```
# Name length = 65
❯ kubectl apply -f examples/controlplane/controlplane.yaml
The ControlPlane "upbound-composition-dynamodb-uptest-uptest-e2e-my-first-ddb-table" is invalid: <nil>: Invalid value: "object": control plane name cannot exceed 63 characters

# Name length = 64
❯ kubectl apply -f examples/controlplane/controlplane.yaml
The ControlPlane "upbound-composition-dynamodb-uptest-uptest-e2e-my-first-ddb-tabl" is invalid: <nil>: Invalid value: "object": control plane name cannot exceed 63 characters

# Name length = 63
❯ kubectl apply -f examples/controlplane/controlplane.yaml
controlplane.spaces.upbound.io/upbound-composition-dynamodb-uptest-uptest-e2e-my-first-ddb-tab created

# After a while for 63 character length
❯ kubectl get ctps
NAME                                                              CROSSPLANE    READY   MESSAGE     AGE
upbound-composition-dynamodb-uptest-uptest-e2e-my-first-ddb-tab   1.18.3-up.1   True    Available   5m5s
```

