### PR TITLE
feat: remove class defaulting and validation from controlplanes crd

### DIFF
--- a/apis/spaces/v1beta1/controlplane_types.go
+++ b/apis/spaces/v1beta1/controlplane_types.go
@@ -192,10 +192,9 @@ type ControlPlaneSpec struct {
 	// requirements. There are multiple predefined classes, with "default"
 	// being the standard Spaces control plane without any additional class
 	// configuration. Check the Upbound Cloud documentation for a list of all
-	// available classes. Defaults to "default".
+	// available classes. Defaults to the configured default class, if not set.
+	// Can only be updated to a compatible class, having the same declared type.
 	// +optional
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="class is immutable"
-	// +kubebuilder:default=default
 	Class string `json:"class,omitempty"`
 }
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

To allow migrating between classes we need to allow updating ControlPlanes' `spec.class`, hence I removed the validation rule.
To allow defaulting at runtime to the runtime default class we need to remove the defaulting to `default` special class.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
