### PR TITLE
Add new ContextTransport and wire up client initiated requestIDs for correlating logs

### DIFF
--- a/client.go
+++ b/client.go
@@ -18,11 +18,14 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"path"
 	"time"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
 
 	uerrors "github.com/upbound/up-sdk-go/errors"
 	"github.com/upbound/up-sdk-go/http/headers"
@@ -114,7 +117,7 @@ func (c *HTTPClient) NewRequest(ctx context.Context, method, prefix, urlPath str
 func (c *HTTPClient) Do(req *http.Request, obj interface{}) error {
 	res, err := c.HTTP.Do(req)
 	if err != nil {
-		return err
+		return errors.Wrap(err, fmt.Sprintf("failed to perform request with ID: %s", request.IDFromContext(req.Context())))
 	}
 	defer res.Body.Close() // nolint:errcheck
 	if err := c.handleErrors(res); err != nil {

--- a/http/headers/headers.go
+++ b/http/headers/headers.go
@@ -1,0 +1,11 @@
+// Copyright 2023 Upbound Inc.
+// All rights reserved
+
+// Package headers provides HTTP header name constants for the headers we care
+// about.
+package headers
+
+// RequestIDHeader is used to uniquely identify a request as it tranverses
+// through the system. See the envoy docs for more information.
+// Ref: https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#x-request-id
+const RequestIDHeader = "x-request-id"

--- a/http/request/request.go
+++ b/http/request/request.go
@@ -1,0 +1,40 @@
+// Copyright 2023 Upbound Inc.
+// All rights reserved
+
+// Package request offers functions for working with requestIDs.
+package request
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+// WithID puts the request ID into the current context.
+func WithID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, contextRequestIDKey, id)
+}
+
+// IDFromContext returns the request ID from the context.
+// A zero ID is returned if there are no idenfiers in the
+// current context.
+func IDFromContext(ctx context.Context) string {
+	v := ctx.Value(contextRequestIDKey)
+	if v == nil {
+		return ""
+	}
+	id, ok := v.(string)
+	if !ok {
+		panic("requestID is not of type string")
+	}
+	return id
+}
+
+// NewID generates a new UUID string.
+func NewID() string {
+	return uuid.NewString()
+}
+
+type contextRequestIDType struct{}
+
+var contextRequestIDKey = &contextRequestIDType{} //nolint:gochecknoglobals //This is intended to be global.


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes
Starting small and adding just requestID. This should be pretty easy to extend in the future if we want to propagate other things from the client.

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
