### PR TITLE
Add capabilities interface to add on

### DIFF
--- a/apis/go.mod
+++ b/apis/go.mod
@@ -3,8 +3,8 @@ module github.com/upbound/up-sdk-go/apis
 go 1.24.3
 
 require (
-	github.com/crossplane/crossplane v1.21.0-rc.0.0.20250712044748-30938ef73ab1
-	github.com/crossplane/crossplane-runtime v1.21.0-rc.0.0.20250620185748-0d81d3f7c2d8
+	github.com/crossplane/crossplane v1.21.0-rc.0.0.20250721080030-e4e442e27027
+	github.com/crossplane/crossplane-runtime v1.21.0-rc.0.0.20250719014028-ab24452c43ea
 	github.com/crossplane/crossplane-tools v0.0.0-20230925130601-628280f8bf79
 	github.com/external-secrets/external-secrets v0.9.13
 	github.com/google/addlicense v1.1.1

--- a/apis/go.sum
+++ b/apis/go.sum
@@ -11,10 +11,10 @@ github.com/bmatcuk/doublestar/v4 v4.0.2/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTS
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
-github.com/crossplane/crossplane v1.21.0-rc.0.0.20250712044748-30938ef73ab1 h1:Ox0wTNunjiQuGJahAqbcBjJM8svZInMV09effWO3lE8=
-github.com/crossplane/crossplane v1.21.0-rc.0.0.20250712044748-30938ef73ab1/go.mod h1:fhgGxEG/07UAg1wrIaQoAmfHdJoj12Sa9USLETJZmxk=
-github.com/crossplane/crossplane-runtime v1.21.0-rc.0.0.20250620185748-0d81d3f7c2d8 h1:QuaMjrEZ97NfoMlTSwZdpLW5IKK3rWZlzvBGk6eAm3Y=
-github.com/crossplane/crossplane-runtime v1.21.0-rc.0.0.20250620185748-0d81d3f7c2d8/go.mod h1:0xIxmt+gYC/LACBVThD4SmN2HDz7o1REjz6ua1qKTdE=
+github.com/crossplane/crossplane v1.21.0-rc.0.0.20250721080030-e4e442e27027 h1:EA4u1s2Sf69mIQgRuACXy/oxk6vG3dSaVdF2j/PzvI4=
+github.com/crossplane/crossplane v1.21.0-rc.0.0.20250721080030-e4e442e27027/go.mod h1:SlUwMSW4yRwlxiOcwyJg/zvk1X6oG60bc46BWklr/tA=
+github.com/crossplane/crossplane-runtime v1.21.0-rc.0.0.20250719014028-ab24452c43ea h1:zaF5R1KBxhyBtrH8QSIeEjGvNzEcSedzwCdfSOZxY/8=
+github.com/crossplane/crossplane-runtime v1.21.0-rc.0.0.20250719014028-ab24452c43ea/go.mod h1:Q2RWQocAsv/2/QF6dYxFyW2XKf9zixqlAG02Fujndag=
 github.com/crossplane/crossplane-tools v0.0.0-20230925130601-628280f8bf79 h1:HigXs5tEQxWz0fcj8hzbU2UAZgEM7wPe0XRFOsrtF8Y=
 github.com/crossplane/crossplane-tools v0.0.0-20230925130601-628280f8bf79/go.mod h1:+e4OaFlOcmr0JvINHl/yvEYBrZawzTgj6pQumOH1SS0=
 github.com/dave/jennifer v1.7.1 h1:B4jJJDHelWcDhlRQxWeo0Npa/pYKBLrirAQoTN45txo=

--- a/apis/pkg/v1alpha1/controllerrevision_types.go
+++ b/apis/pkg/v1alpha1/controllerrevision_types.go
@@ -134,6 +134,16 @@ func (in *ControllerRevision) CleanConditions() {
 	in.Status.Conditions = []xpv1.Condition{}
 }
 
+// GetCapabilities of this ControllerRevision.
+func (in *ControllerRevision) GetCapabilities() []string {
+	return in.Status.Capabilities
+}
+
+// SetCapabilities of this ControllerRevision.
+func (in *ControllerRevision) SetCapabilities(caps []string) {
+	in.Status.Capabilities = caps
+}
+
 // GetObjects returns the objects associated with the ControllerRevision.
 func (in *ControllerRevision) GetObjects() []xpv1.TypedReference {
 	return in.Status.ObjectRefs

--- a/apis/pkg/v1alpha1/remoteconfigurationrevision_types.go
+++ b/apis/pkg/v1alpha1/remoteconfigurationrevision_types.go
@@ -104,6 +104,16 @@ func (in *RemoteConfigurationRevision) CleanConditions() {
 	in.Status.Conditions = []xpv1.Condition{}
 }
 
+// GetCapabilities of this RemoteConfigurationRevision.
+func (in *RemoteConfigurationRevision) GetCapabilities() []string {
+	return in.Status.Capabilities
+}
+
+// SetCapabilities of this RemoteConfigurationRevision.
+func (in *RemoteConfigurationRevision) SetCapabilities(caps []string) {
+	in.Status.Capabilities = caps
+}
+
 // GetObjects returns the objects.
 func (in *RemoteConfigurationRevision) GetObjects() []xpv1.TypedReference {
 	return in.Status.ObjectRefs

--- a/apis/pkg/v1beta1/addonrevision_types.go
+++ b/apis/pkg/v1beta1/addonrevision_types.go
@@ -136,6 +136,16 @@ func (in *AddOnRevision) CleanConditions() {
 	in.Status.Conditions = []xpv1.Condition{}
 }
 
+// GetCapabilities of this AddOnRevision.
+func (in *AddOnRevision) GetCapabilities() []string {
+	return in.Status.Capabilities
+}
+
+// SetCapabilities of this AddOnRevision.
+func (in *AddOnRevision) SetCapabilities(caps []string) {
+	in.Status.Capabilities = caps
+}
+
 // GetObjects returns the objects associated with the AddOnRevision.
 func (in *AddOnRevision) GetObjects() []xpv1.TypedReference {
 	return in.Status.ObjectRefs


### PR DESCRIPTION
### Description of your changes

Bumps Crossplane and runtime dependencies in apis go.mod and adds capability methods to addon revision to keep satisfying package revision interface.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR, as appropriate.~

### How has this code been tested

make reviewable & code compiles.