### PR TITLE
Add resource and columns to query request/response

### DIFF
--- a/apis/query/v1alpha2/query_types.go
+++ b/apis/query/v1alpha2/query_types.go
@@ -281,6 +281,14 @@ type QueryObjects struct {
 	// object should be returned.
 	ControlPlane bool `json:"controlPlane,omitempty"`
 
+	// resource specifies that the plural name of the object's type should be
+	// returned.
+	Resource bool `json:"resource,omitempty"`
+
+	// printerColumns specifies that the list of printer columns for the
+	// object's type should be returned.
+	PrinterColumns bool `json:"printerColumns,omitempty"`
+
 	// object specifies how to return the object, i.e. a sparse skeleton of
 	// fields. A value of true means that all descendants of that field should
 	// be returned. Other primitive values are not allowed. If the type of

--- a/apis/query/v1alpha2/queryresponse_types.go
+++ b/apis/query/v1alpha2/queryresponse_types.go
@@ -15,6 +15,7 @@
 package v1alpha2
 
 import (
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/upbound/up-sdk-go/apis/common"
@@ -94,6 +95,12 @@ type QueryResponseObject struct {
 
 	// controlPlane is the name and namespace of the object.
 	ControlPlane *QueryResponseControlPlane `json:"controlPlane,omitempty"`
+
+	// resource is the plural name of the object's type.
+	Resource string `json:"resource,omitempty"`
+
+	// printerColumns is the list of printer columns for the object's type.
+	PrinterColumns []apiextensionsv1.CustomResourceColumnDefinition `json:"printerColumns,omitempty"`
 
 	// object is the sparse representation of the object.
 	Object *common.JSONObject `json:"object,omitempty"`

--- a/apis/query/v1alpha2/zz_generated.deepcopy.go
+++ b/apis/query/v1alpha2/zz_generated.deepcopy.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v1alpha2
 
 import (
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -411,6 +412,11 @@ func (in *QueryResponseObject) DeepCopyInto(out *QueryResponseObject) {
 		in, out := &in.ControlPlane, &out.ControlPlane
 		*out = new(QueryResponseControlPlane)
 		**out = **in
+	}
+	if in.PrinterColumns != nil {
+		in, out := &in.PrinterColumns, &out.PrinterColumns
+		*out = make([]apiextensionsv1.CustomResourceColumnDefinition, len(*in))
+		copy(*out, *in)
 	}
 	if in.Object != nil {
 		in, out := &in.Object, &out.Object


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

As part of GLO-254

To support an alternative to querying directly for CRDs, allow Query API queries to return with the plural of a resource and its printer columns.

I have:

- [ ] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
